### PR TITLE
Set default kernel args, modprobe blacklist

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -32,3 +32,5 @@
     DIB_PYTHON_VERSION: '3'
     DIB_DHCP_TIMEOUT: '60'
     DIB_IMAGE_SIZE: '4'
+    DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
+    DIB_BOOTLOADER_DEFAULT_CMDLINE: 'nofb nomodeset vga=normal audit=1 nousb'

--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -34,3 +34,4 @@
     DIB_IMAGE_SIZE: '4'
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
     DIB_BOOTLOADER_DEFAULT_CMDLINE: 'nofb nomodeset vga=normal audit=1 nousb'
+    DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''


### PR DESCRIPTION
This pulls in DIB_MODPROBE_BLACKLIST, DIB_BOOTLOADER_DEFAULT_CMDLINE from tripleo-common image definition. "console=" kernel arguments are left off because diskimage-builder bootloader element manages these.