### PR TITLE
Remove all kernel arguments

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -33,5 +33,5 @@
     DIB_DHCP_TIMEOUT: '60'
     DIB_IMAGE_SIZE: '4'
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
-    DIB_BOOTLOADER_DEFAULT_CMDLINE: 'nofb nomodeset vga=normal audit=1 nousb'
+    DIB_BOOTLOADER_DEFAULT_CMDLINE: ''
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''


### PR DESCRIPTION
See the chain of tripleo-common changes[1] for the rationale of each removal.

[1] https://review.opendev.org/c/openstack/tripleo-common/+/881388