### PR TITLE
Add ironic-python-agent-rhel-9.yaml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,11 @@ The CentOS-9-Stream version of ``ironic-python-agent.initramfs`` and
 
     diskimage-builder ./images/ironic-python-agent-centos-9-stream.yaml
 
+Similarly, the rhel-9 version can be built with master branch
+``current-podified`` by running::
+
+    diskimage-builder ./images/ironic-python-agent-rhel-9.yaml
+
 ``ironic-python-agent.qcow2`` can be packaged inside a container image for
 distribution by running::
 

--- a/images/ironic-python-agent-rhel-9.yaml
+++ b/images/ironic-python-agent-rhel-9.yaml
@@ -1,0 +1,23 @@
+- imagename: ironic-python-agent
+  elements:
+  # diskimage-builder elements
+  - rhel
+  - dynamic-login
+  - element-manifest
+  - selinux-permissive
+  # edpm-image-builder elements
+  - enable-packages-install
+  - interface-names
+  - ironic-agent-multipath
+  - override-pip-and-virtualenv
+  # ironic-python-agent-builder elements
+  - extra-hardware
+  - ironic-python-agent-ramdisk
+  - repo-setup
+  min-tmpfs: 7
+  debug-trace: 1
+  checksum: true
+  environment:
+    DIB_EPEL_DISABLED: '1'
+    DIB_PYTHON_VERSION: '3'
+    DIB_DHCP_TIMEOUT: '60'


### PR DESCRIPTION
This yaml has been tested downstream to build IPA
images on rhel-9.