### PR TITLE
Add edpm baremetal CI job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,8 @@
+---
+- job:
+    name: eib-content-provider-build-images
+    parent: content-provider-build-images-base
+
+- job:
+    name: eib-crc-podified-edpm-baremetal
+    parent: cifmw-crc-podified-edpm-baremetal

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,9 @@
+---
+- project:
+    name: openstack-k8s-operators/edpm-image-builder
+    github-check:
+      jobs:
+        - eib-content-provider-build-images 
+        - eib-crc-podified-edpm-baremetal: &eib_content_provider
+            dependencies:
+              - eib-content-provider-build-images


### PR DESCRIPTION
It adds following jobs which will run against edpm-image-builder.

- eib-content-provider-build-images job which will build edpm and ipa images and push it to local registry. The job will be paused to serve as a registry.
- eib-crc-podified-edpm-baremetal is the child job which will pull the required edpm and ipa images from content provider. The Zuul will pass the necessary vars to the child job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/324