### PR TITLE
Fix Containerfile and copy_out.sh location

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifier =
 data_files =
     share/edpm-image-builder/dib = dib/*
     share/edpm-image-builder/images = images/*
-    share/edpm-image-builder/Containerfile.image = Containerfile.image
-    share/edpm-image-builder/Containerfile.ramdisk = Containerfile.ramdisk
-    share/edpm-image-builder/copy_out.sh = copy_out.sh
+    share/edpm-image-builder =
+        Containerfile.image
+        Containerfile.ramdisk
+        copy_out.sh


### PR DESCRIPTION
we want `Containerfile.image` and `copy_out.sh` in `/usr/share/edpm-image-builder/ directory`

Currently, Containerfile.image file is in
`/usr/share/edpm-image-builder/Containerfile.image` directory instead of `/usr/share/edpm-image-builder/` and same for ramdisk and copy_out.sh they are in their own directory.

~~~
$ cat /usr/share/edpm-image-builder/Containerfile.image/Containerfile.image ARG BASE_IMAGE=quay.io/centos/centos:stream9-minimal ..
~~~