### PR TITLE
Add tc command

### DIFF
--- a/dib/edpm-base/package-installs.yaml
+++ b/dib/edpm-base/package-installs.yaml
@@ -18,6 +18,7 @@ rsync:
 tmpwatch:
 tuned-profiles-cpu-partitioning:
 sysstat:
+iproute-tc:
 # Remove for hardened image requirements
 kexec-tools:
   uninstall: True


### PR DESCRIPTION
The command allows us to capture qdisc drop counter, which is useful for debugging packet loss problems.