### PR TITLE
Make edpm-hardened-uefi FIPs enabled

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -12,6 +12,7 @@
   - modprobe
   - disable-nouveau
   - reset-bls-entries
+  - fips
   # edpm-image-builder elements
   - edpm-base
   - edpm-partition-uefi


### PR DESCRIPTION
The aim is to make FIPs enabled by default for EDPM nodes, adding the fips element is all that is required to do that.

Jira: OSP-25912