### PR TITLE
Increase edpm image and root partition by 1GiB

### DIFF
--- a/dib/edpm-partition-uefi/block-device-default.yaml
+++ b/dib/edpm-partition-uefi/block-device-default.yaml
@@ -31,7 +31,7 @@
         flags: [ boot ]
         # The passed-in DIB_IMAGE_SIZE is       4GiB, 4096MiB
         # Otherwise, there is a 2MiB overhead
-        size: 3570MiB
+        size: 4594MiB
 - lvm:
     name: lvm
     base: [ root ]
@@ -48,14 +48,14 @@
           type: thin-pool
           base: vg
           # 20MiB overhead from root partition size
-          size: 3550MiB
+          size: 4574MiB
         - name: lv_root
           type: thin
           thin-pool: lv_thinpool
           base: vg
           # Volume sizes should be a multiple of 4MiB (1 LVM extent)
-          # so this is rounded down from 1566MiB
-          size: 1396MiB
+          # so this is rounded down from 2422MiB
+          size: 2420MiB
         - name: lv_tmp
           type: thin
           thin-pool: lv_thinpool

--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -28,7 +28,7 @@
     DIB_EPEL_DISABLED: '1'
     DIB_PYTHON_VERSION: '3'
     DIB_DHCP_TIMEOUT: '60'
-    DIB_IMAGE_SIZE: '4'
+    DIB_IMAGE_SIZE: '5'
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
     # TODO remove memtest=0 when this change is available:
     # https://review.opendev.org/c/openstack/diskimage-builder/+/884644

--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -26,7 +26,7 @@
     DIB_RELEASE: '9'
     DIB_PYTHON_VERSION: '3'
     DIB_DHCP_TIMEOUT: '60'
-    DIB_IMAGE_SIZE: '4'
+    DIB_IMAGE_SIZE: '5'
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
     # TODO remove memtest=0 when this change is available:
     # https://review.opendev.org/c/openstack/diskimage-builder/+/884644


### PR DESCRIPTION
Building a rhel 9.2 based image is currently failing because the root partition is full.

This change increases the size of the edpm-hardened-uefi image from 4GiB to 5GiB and gives that extra space to the root partition.

Jira: OSPCIX-41