### PR TITLE
Re-Add interface-names element

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -16,6 +16,7 @@
   - edpm-base
   - edpm-partition-uefi
   - enable-packages-install
+  - interface-names
   - openvswitch
   - override-pip-and-virtualenv
   - remove-resolvconf

--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -15,6 +15,7 @@
   - edpm-base
   - edpm-partition-uefi
   - enable-packages-install
+  - interface-names
   - openvswitch
   - override-pip-and-virtualenv
   - remove-resolvconf


### PR DESCRIPTION
It was recently removed and this causes issues with stable interface names as not removing `net.ifnames=0` from `GRUB_CMDLINE_LINUX` results in interface names in old ethx style.