### PR TITLE
Added ceph dib element

### DIFF
--- a/dib/ceph/REAMDE.md
+++ b/dib/ceph/REAMDE.md
@@ -1,0 +1,1 @@
+Install ceph from packages.

--- a/dib/ceph/element-deps
+++ b/dib/ceph/element-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/dib/ceph/package-installs.yaml
+++ b/dib/ceph/package-installs.yaml
@@ -1,0 +1,2 @@
+cephadm:
+bind-utils:


### PR DESCRIPTION
It will install ceph related packages in the edpm image. It is an optional element, not enabled by default in the edpm image.