### PR TITLE
Revert "Make edpm-hardened-uefi FIPs enabled"

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -12,7 +12,6 @@
   - modprobe
   - disable-nouveau
   - reset-bls-entries
-  - fips
   # edpm-image-builder elements
   - edpm-base
   - edpm-partition-uefi


### PR DESCRIPTION
It appears that the host trunk.rdoproject.org has a TLS setup which is not FIPS compliant:

raise SSLError(e, request=request)\nrequests.exceptions.SSLError: HTTPSConnectionPool(host='trunk.rdoproject.org', port=443): Max retries exceeded with url: /centos9-antelope/current-podified/delorean.repo (Caused by SSLError(SSLError(1, '[SSL] unsupported (_ssl.c:1129)

Lets revert while we investigate.

This reverts commit ba423841db9e0d63583071ddf9d8372d0353fbec.