### PR TITLE
Revert "Revert "Make edpm-hardened-uefi FIPs enabled""

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -12,6 +12,7 @@
   - modprobe
   - disable-nouveau
   - reset-bls-entries
+  - fips
   # edpm-image-builder elements
   - edpm-base
   - edpm-partition-uefi


### PR DESCRIPTION
Revert "Revert "Make edpm-hardened-uefi FIPs enabled""

Enable FIPS again, requiring a relaxation of the policy to make
connections to trunk.rdoproject.org.

This reverts commit 8691ad87988908b008d237855ba74856c9458522.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/607
