### PR TITLE
Remove no_timer_check kernel boot option

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -36,3 +36,4 @@
     # https://review.opendev.org/c/openstack/diskimage-builder/+/884644
     DIB_BOOTLOADER_DEFAULT_CMDLINE: 'memtest=0'
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''
+    DIB_NO_TIMER_CHECK: 'False'

--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -11,6 +11,7 @@
   - modprobe
   - disable-nouveau
   - reset-bls-entries
+  - fips
   # edpm-image-builder elements
   - edpm-base
   - edpm-partition-uefi
@@ -33,3 +34,4 @@
     # https://review.opendev.org/c/openstack/diskimage-builder/+/884644
     DIB_BOOTLOADER_DEFAULT_CMDLINE: 'memtest=0'
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''
+    DIB_NO_TIMER_CHECK: 'False'


### PR DESCRIPTION
This option causes some AMD environments to fail to boot. It should be safe to remove for all hardware since it was only added to improve performance on VM workloads.

Depending on dib change [1] is not strict, but the option will only be removed when both changes are present.

[1] https://review.opendev.org/c/openstack/diskimage-builder/+/904780
Depends-On: I8b9697ba60748bfe1e1e1914f24f207439cda2f1

Change-Id: Ic463fb65ea69f48ffdd0277731cb2f9a3a5ee1e2