### PR TITLE
Enable FIPS for just the RHEL image

### DIFF
--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -11,6 +11,7 @@
   - modprobe
   - disable-nouveau
   - reset-bls-entries
+  - fips
   # edpm-image-builder elements
   - edpm-base
   - edpm-partition-uefi


### PR DESCRIPTION
FIPS is currently not enabled on the CentOS image because upstream CI cannot consistently provide enough entropy to pass FIPS requirements. However FIPS still needs to be enabled by default, so this change adds FIPS support to the RHEL EDPM image.

Similar issues may be found downstream but we need to try it to find out. The workaround may be different downstream, such as getting VM based jobs to modify the image to disable FIPS on-the-fly.

Issue: OSPRH-1196