### PR TITLE
Add separate yaml files just to enable the fips element

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,11 @@ master branch ``current-podified`` by running::
 
     diskimage-builder ./images/edpm-hardened-uefi-centos-9-stream.yaml
 
+To create a FIPS enabled image, add ``edpm-hardened-uefi-fips.yaml`` to
+include the ``fips`` element::
+
+    diskimage-builder ./images/edpm-hardened-uefi-centos-9-stream.yaml ./images/edpm-hardened-uefi-fips.yaml
+
 See dib/repo-setup/README.md for environment variables to control which RDO
 repositories to configure.
 

--- a/images/edpm-hardened-uefi-fips.yaml
+++ b/images/edpm-hardened-uefi-fips.yaml
@@ -1,0 +1,4 @@
+- imagename: edpm-hardened-uefi
+  elements:
+  # Additional element to enable fips for other image defintion
+  - fips

--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -11,7 +11,6 @@
   - modprobe
   - disable-nouveau
   - reset-bls-entries
-  - fips
   # edpm-image-builder elements
   - edpm-base
   - edpm-partition-uefi

--- a/images/ironic-python-agent-fips.yaml
+++ b/images/ironic-python-agent-fips.yaml
@@ -1,0 +1,4 @@
+- imagename: ironic-python-agent
+  elements:
+  # Additional element to enable fips for other image defintion
+  - fips


### PR DESCRIPTION
This simply allows a FIPS image to be created or not, rather than images
being FIPS by default.

This also reverts the RHEL image being FIPS by default. Downstream builds currently enable FIPS differently and this likely breaks the non-FIPS image build