### PR TITLE
Add FIPS required packages to default package list

### DIFF
--- a/dib/edpm-base/package-installs.yaml
+++ b/dib/edpm-base/package-installs.yaml
@@ -1,7 +1,9 @@
 buildah:
 chrony:
 crudini:
+crypto-policies-scripts:
 driverctl:
+grubby:
 iptables-services:
 jq:
 lvm2:


### PR DESCRIPTION
These packages are used by the edpm-ansible tasks which enable FIPS.