### PR TITLE
Fix "Multiple top-level packages discovered in a flat-layout" error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,9 @@ classifier =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
+[options]
+packages =
+
 [entry_points]
 
 [files]


### PR DESCRIPTION
Since setuptools 61.1.0 [1], building and installing edmp-image-builder is failing with error:

error: Multiple top-level packages discovered in a flat-layout: ['dib', 'images'].

Note that edpm-image-builder does not contains any actual python module but it's just python install tooling for convenience.

[1] https://setuptools.pypa.io/en/latest/history.html#v61-1-0