### PR TITLE
Create /run/install to restore grub2-mkconfig behaviour

### DIFF
--- a/dib/host-ca/README.rst
+++ b/dib/host-ca/README.rst
@@ -1,0 +1,18 @@
+host-ca
+=======
+
+host-ca is an element to copy certificate authority files from the host into the
+image, then run ``update-ca-trust``.
+
+To use, set DIB_HOST_CA to a list of files on the build host in directory
+``/etc/pki/ca-trust/source/anchors/``, for example::
+
+    export DIB_HOST_CA="2015-RH-IT-Root-CA.pem 2022-IT-Root-CA.pem"
+
+Or in a ``diskimage-builder`` command yaml file::
+
+    - imagename: edpm-hardened-uefi
+    elements:
+    - host-ca
+    environment:
+        DIB_HOST_CA: "2015-RH-IT-Root-CA.pem 2022-IT-Root-CA.pem"

--- a/dib/host-ca/extra-data.d/10-host-ca
+++ b/dib/host-ca/extra-data.d/10-host-ca
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+if [ ${DIB_DEBUG_TRACE:-1} -gt 0 ]; then
+    set -x
+fi
+
+if [ -n "$DIB_HOST_CA" ]; then
+    for ca_file in $DIB_HOST_CA; do
+        sudo cp /etc/pki/ca-trust/source/anchors/$ca_file $TMP_MOUNT_PATH/etc/pki/ca-trust/source/anchors/
+    done
+fi

--- a/dib/host-ca/pre-install.d/00-host-ca
+++ b/dib/host-ca/pre-install.d/00-host-ca
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+if [ ${DIB_DEBUG_TRACE:-1} -gt 0 ]; then
+    set -x
+fi
+
+if [ -n "$DIB_HOST_CA" ]; then
+    sudo update-ca-trust
+fi

--- a/dib/reset-bls-entries/finalise.d/49-mkdir-run-install
+++ b/dib/reset-bls-entries/finalise.d/49-mkdir-run-install
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# Ensure running grub2-mkconfig results in BLS entries being updated
+# See https://pkgs.devel.redhat.com/cgit/rpms/grub2/tree/0328-grub2-mkconfig-Pass-all-boot-params-when-used-by-ana.patch?h=rhel-9.3.0
+mkdir /run/install

--- a/dib/reset-bls-entries/finalise.d/51-rm-run-install
+++ b/dib/reset-bls-entries/finalise.d/51-rm-run-install
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# Cleanup /run/install directory, see 49-mkdir-run-install
+rm -rf /run/install


### PR DESCRIPTION

Older versions of grub2-mkconfig will update the kernel arguments in BLS
files, but this now only happens when the --update-bls-cmdline argument
is passed, see [1]. Rather than pass --update-bls-cmdline, this change
creates the directory /run/install which restores the old behaviour for
new installs, see [2].
    
Issue: OSPCIX-200
    
[1] https://pkgs.devel.redhat.com/cgit/rpms/grub2/tree/0327-grub-mkconfig-dont-overwrite-BLS-cmdline-if-BLSCFG.patch?h=rhel-9.3.0
[2] https://pkgs.devel.redhat.com/cgit/rpms/grub2/tree/0328-grub2-mkconfig-Pass-all-boot-params-when-used-by-ana.patch?h=rhel-9.3.0
