### PR TITLE
Replace efi grub.cfg with RHEL style redirect

### DIFF
--- a/dib/edpm-partition-uefi/finalise.d/51-efi-grub-cfg
+++ b/dib/edpm-partition-uefi/finalise.d/51-efi-grub-cfg
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-1} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+GRUB_CFG=/boot/efi/$EFI_BOOT_DIR/grub.cfg
+GRUBENV=/boot/efi/$EFI_BOOT_DIR/grubenv
+if [ -a $GRUB_CFG ]; then
+    rm $GRUB_CFG
+fi
+if [ -a $GRUBENV ]; then
+    rm $GRUBENV
+fi
+cat > $GRUB_CFG << EOF
+search --no-floppy --set prefix --file /grub2/grub.cfg
+set prefix=(\$prefix)/grub2
+configfile \$prefix/grub.cfg
+EOF


### PR DESCRIPTION
Currently the efi grub.cfg is identical to the /boot/grub2/grub.cfg,
which only occurs thanks to a second manual call to grub2-mkconfig. This
risks out-of-band updates resulting in a stale efi grub.cfg, which in
some cases may prevent the host from booting at all.

The RHEL efi grub.cfg is a simple redirect to the /boot partition. This
change replicates this redirect.

A corresponding change to edpm-ansible will stop overwriting efi
grub.cfg with the previous approach.

Jira: OSPRH-7209