### PR TITLE
Set kernel argument rd.multipath=default

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -31,7 +31,5 @@
     DIB_DHCP_TIMEOUT: '60'
     DIB_IMAGE_SIZE: '5'
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
-    # TODO remove memtest=0 when this change is available:
-    # https://review.opendev.org/c/openstack/diskimage-builder/+/884644
-    DIB_BOOTLOADER_DEFAULT_CMDLINE: 'memtest=0'
+    DIB_BOOTLOADER_DEFAULT_CMDLINE: 'rd.multipath=default'
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''


### PR DESCRIPTION
This is required to boot in some multipath environments, and should have no effect in non-multipath environments.

Since there is always a non-empty DIB_BOOTLOADER_DEFAULT_CMDLINE now, the placeholder argument and TODO is removed.

Depends-On: https://github.com/openstack-k8s-operators/edpm-image-builder/pull/33