### PR TITLE
Use vexxhost nodeset in eib-content-provider-build-images

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2,6 +2,7 @@
 - job:
     name: eib-content-provider-build-images
     parent: content-provider-build-images-base
+    nodeset: centos-stream-9-vexxhost
 
 - job:
     name: eib-crc-podified-edpm-baremetal


### PR DESCRIPTION
This pr will make sure that EDPM content provider will always run on vexxhost cloud having public ips.

The EDPM dependent job will always pull the image from public IP and avoid ImagePullErr failure.