### PR TITLE
Set DIB_BOOTLOADER_USE_SERIAL_CONSOLE to false

### DIFF
--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -33,3 +33,4 @@
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
     DIB_BOOTLOADER_DEFAULT_CMDLINE: 'rd.multipath=default'
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''
+    DIB_BOOTLOADER_USE_SERIAL_CONSOLE: 'False'

--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -31,3 +31,4 @@
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
     DIB_BOOTLOADER_DEFAULT_CMDLINE: 'rd.multipath=default'
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''
+    DIB_BOOTLOADER_USE_SERIAL_CONSOLE: 'False'

--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -29,7 +29,5 @@
     DIB_DHCP_TIMEOUT: '60'
     DIB_IMAGE_SIZE: '5'
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
-    # TODO remove memtest=0 when this change is available:
-    # https://review.opendev.org/c/openstack/diskimage-builder/+/884644
-    DIB_BOOTLOADER_DEFAULT_CMDLINE: 'memtest=0'
+    DIB_BOOTLOADER_DEFAULT_CMDLINE: 'rd.multipath=default'
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''


### PR DESCRIPTION
Any console=tty0 or console=ttyS0 arguments can cause latency
regressions in networking. Setting DIB_BOOTLOADER_USE_SERIAL_CONSOLE to
false will prevent any console arguments being added, and will also
remove any console arguments from BLS entries.

Jira: OSPRH-8037