### PR TITLE
Add logically bound images for EDPM services

### DIFF
--- a/bootc/Containerfile.centos9
+++ b/bootc/Containerfile.centos9
@@ -4,36 +4,36 @@ RUN rm -rf /etc/yum.repos.d/*.repo
 COPY output/yum.repos.d /etc/yum.repos.d
 
 ARG PACKAGES="\
-    bind-utils \
-    buildah \
-    cephadm \
-    chrony \
-    cloud-init \
-    cronie \
-    crudini \
-    crypto-policies-scripts \
-    device-mapper-multipath \
-    driverctl \
-    grubby \
-    iproute-tc \
-    iptables-services \
-    iscsi-initiator-utils \
-    jq \
-    lvm2 \
-    nftables \
-    numactl \
-    openssh-server \
-    openstack-network-scripts \
-    openstack-selinux \
-    openvswitch \
-    os-net-config \
-    podman \
-    python3-libselinux \
-    python3-pyyaml \
-    rsync \
-    tmpwatch \
-    tuned-profiles-cpu-partitioning \
-    sysstat"
+	bind-utils \
+	buildah \
+	cephadm \
+	chrony \
+	cloud-init \
+	cronie \
+	crudini \
+	crypto-policies-scripts \
+	device-mapper-multipath \
+	driverctl \
+	grubby \
+	iproute-tc \
+	iptables-services \
+	iscsi-initiator-utils \
+	jq \
+	lvm2 \
+	nftables \
+	numactl \
+	openssh-server \
+	openstack-network-scripts \
+	openstack-selinux \
+	openvswitch \
+	os-net-config \
+	podman \
+	python3-libselinux \
+	python3-pyyaml \
+	rsync \
+	tmpwatch \
+	tuned-profiles-cpu-partitioning \
+	sysstat"
 ARG ENABLE_UNITS="openvswitch"
 
 RUN dnf -y install $PACKAGES && dnf clean all && systemctl enable $ENABLE_UNITS
@@ -46,3 +46,31 @@ RUN ln -s /etc/sysconfig/network-scripts/ifdown /usr/sbin/ifdown
 # Drop Ansible fact into place
 COPY ansible-facts/bootc.fact /usr/etc/ansible/facts.d/bootc.fact
 RUN chmod +x /usr/etc/ansible/facts.d/bootc.fact
+
+# Template systemd service for services
+COPY embedded-services/quadlets/systemd/service-template.kube /usr/share/containers/systemd/edpm-compute@.kube
+
+## Service specific quadlets
+COPY embedded-services/quadlets/ovn-controller/ovn_controller.yaml /usr/share/containers/systemd/ovn_controller.yaml
+COPY embedded-services/quadlets/ovn-controller/ovn_controller.image /usr/share/containers/systemd/ovn_controller.image
+COPY embedded-services/quadlets/iscsid/iscsid.yaml /usr/share/containers/systemd/iscsid.yaml
+COPY embedded-services/quadlets/iscsid/iscsid.image /usr/share/containers/systemd/iscsid.image
+COPY embedded-services/quadlets/nova_compute/nova_compute.yaml /usr/share/containers/systemd/nova_compute.yaml
+COPY embedded-services/quadlets/nova_compute/nova_compute.image /usr/share/containers/systemd/nova_compute.image
+COPY embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.yaml /usr/share/containers/systemd/ovn_metadata_agent.yaml
+COPY embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.image /usr/share/containers/systemd/ovn_metadata_agent.image
+COPY embedded-services/quadlets/logrotate_crond/logrotate_crond.yaml /usr/share/containers/systemd/logrotate_crond.yaml
+COPY embedded-services/quadlets/logrotate_crond/logrotate_crond.image /usr/share/containers/systemd/logrotate_crond.image
+COPY embedded-services/quadlets/multipathd/multipathd.yaml /usr/share/containers/systemd/multipathd.yaml
+COPY embedded-services/quadlets/multipathd/multipathd.image /usr/share/containers/systemd/multipathd.image
+COPY embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.yaml /usr/share/containers/systemd/ceilometer_agent_compute.yaml
+COPY embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.image /usr/share/containers/systemd/ceilometer_agent_compute.image
+
+# Pre-cache containers for each service
+RUN podman pull quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
+RUN podman pull quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
+RUN podman pull quay.io/podified-antelope-centos9/openstack-cron:current-podified
+RUN podman pull quay.io/podified-antelope-centos9/openstack-multipathd:current-podified
+RUN podman pull quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+RUN podman pull quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
+RUN podman pull quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified

--- a/bootc/Containerfile.centos9
+++ b/bootc/Containerfile.centos9
@@ -19,6 +19,8 @@ ARG PACKAGES="\
 	iptables-services \
 	iscsi-initiator-utils \
 	jq \
+	libvirt \
+	libvirt-daemon-driver-qemu \
 	lvm2 \
 	nftables \
 	numactl \
@@ -29,6 +31,7 @@ ARG PACKAGES="\
 	os-net-config \
 	podman \
 	python3-libselinux \
+	python3-pyroute2 \
 	python3-pyyaml \
 	rsync \
 	tmpwatch \
@@ -51,20 +54,7 @@ RUN chmod +x /usr/etc/ansible/facts.d/bootc.fact
 COPY embedded-services/quadlets/systemd/service-template.kube /usr/share/containers/systemd/edpm-compute@.kube
 
 ## Service specific quadlets
-COPY embedded-services/quadlets/ovn-controller/ovn_controller.yaml /usr/share/containers/systemd/ovn_controller.yaml
-COPY embedded-services/quadlets/ovn-controller/ovn_controller.image /usr/share/containers/systemd/ovn_controller.image
-COPY embedded-services/quadlets/iscsid/iscsid.yaml /usr/share/containers/systemd/iscsid.yaml
-COPY embedded-services/quadlets/iscsid/iscsid.image /usr/share/containers/systemd/iscsid.image
-COPY embedded-services/quadlets/nova_compute/nova_compute.yaml /usr/share/containers/systemd/nova_compute.yaml
-COPY embedded-services/quadlets/nova_compute/nova_compute.image /usr/share/containers/systemd/nova_compute.image
-COPY embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.yaml /usr/share/containers/systemd/ovn_metadata_agent.yaml
-COPY embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.image /usr/share/containers/systemd/ovn_metadata_agent.image
-COPY embedded-services/quadlets/logrotate_crond/logrotate_crond.yaml /usr/share/containers/systemd/logrotate_crond.yaml
-COPY embedded-services/quadlets/logrotate_crond/logrotate_crond.image /usr/share/containers/systemd/logrotate_crond.image
-COPY embedded-services/quadlets/multipathd/multipathd.yaml /usr/share/containers/systemd/multipathd.yaml
-COPY embedded-services/quadlets/multipathd/multipathd.image /usr/share/containers/systemd/multipathd.image
-COPY embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.yaml /usr/share/containers/systemd/ceilometer_agent_compute.yaml
-COPY embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.image /usr/share/containers/systemd/ceilometer_agent_compute.image
+COPY embedded-services/quadlets/*/* /usr/share/containers/systemd/
 
 # Pre-cache containers for each service
 RUN podman pull quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified

--- a/bootc/embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.image
+++ b/bootc/embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@ceilometer_agent_compute.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified

--- a/bootc/embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.yaml
+++ b/bootc/embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/cacerts/telemetry/tls-ca-bundle.pem:z
+  labels:
+    app: ceilometeragentcompute
+  name: ceilometeragentcompute
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    - name: OS_ENDPOINT_TYPE
+      value: internal
+    image: quay.io/podified-antelope-centos9/openstack-ceilometer-compute@sha256:f6bba9df7ce1d877daa7fe2cd36e5149b99ded1f3e9b88576944d83a4429f25b
+    name: ceilometeragentcompute
+    securityContext:
+      runAsGroup: 42405
+      runAsUser: 42405
+      seLinuxOptions:
+        type: ceilometer_polling_t
+    volumeMounts:
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-ceilometer_agent_compute-host-0
+      readOnly: true
+    - mountPath: /etc/pki/tls/certs/ca-bundle.trust.crt
+      name: etc-pki-tls-certs-ca-bundle.trust.crt-host-1
+      readOnly: true
+    - mountPath: /run/libvirt
+      name: run-libvirt-host-2
+      readOnly: true
+    - mountPath: /dev/log
+      name: dev-log-host-3
+    - mountPath: /etc/pki/ca-trust/source/anchors
+      name: etc-pki-ca-trust-source-anchors-host-4
+      readOnly: true
+    - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      name: var-lib-openstack-cacerts-telemetry-tls-ca-bundle.pem-host-5
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-openstack-config-telemetry-ceilometer-agent-compute.json-host-6
+    - mountPath: /etc/hosts
+      name: etc-hosts-host-7
+      readOnly: true
+    - mountPath: /var/lib/openstack/config/
+      name: var-lib-openstack-config-telemetry-host-8
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-9
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/ceilometer_agent_compute
+      type: Directory
+    name: var-lib-openstack-healthchecks-ceilometer_agent_compute-host-0
+  - hostPath:
+      path: /etc/pki/tls/certs/ca-bundle.trust.crt
+      type: File
+    name: etc-pki-tls-certs-ca-bundle.trust.crt-host-1
+  - hostPath:
+      path: /run/libvirt
+      type: Directory
+    name: run-libvirt-host-2
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-3
+  - hostPath:
+      path: /etc/pki/ca-trust/source/anchors
+      type: Directory
+    name: etc-pki-ca-trust-source-anchors-host-4
+  - hostPath:
+      path: /var/lib/openstack/cacerts/telemetry/tls-ca-bundle.pem
+      type: File
+    name: var-lib-openstack-cacerts-telemetry-tls-ca-bundle.pem-host-5
+  - hostPath:
+      path: /var/lib/openstack/config/telemetry/ceilometer-agent-compute.json
+      type: File
+    name: var-lib-openstack-config-telemetry-ceilometer-agent-compute.json-host-6
+  - hostPath:
+      path: /etc/hosts
+      type: File
+    name: etc-hosts-host-7
+  - hostPath:
+      path: /var/lib/openstack/config/telemetry
+      type: Directory
+    name: var-lib-openstack-config-telemetry-host-8
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-9

--- a/bootc/embedded-services/quadlets/iscsid/iscsid.image
+++ b/bootc/embedded-services/quadlets/iscsid/iscsid.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@iscsid.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-iscsid:current-podified

--- a/bootc/embedded-services/quadlets/iscsid/iscsid.yaml
+++ b/bootc/embedded-services/quadlets/iscsid/iscsid.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /etc/iscsi:z
+  creationTimestamp: "2024-12-09T02:00:14Z"
+  labels:
+    app: iscsid
+  name: iscsid
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    image: quay.io/podified-antelope-centos9/openstack-iscsid@sha256:4c9b5389a2564388e7a862d5756c37dc7d9739472b8d822dd6faae868a483a2d
+    name: iscsid
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /etc/pki/ca-trust/source/anchors
+      name: etc-pki-ca-trust-source-anchors-host-0
+      readOnly: true
+    - mountPath: /etc/target
+      name: etc-target-host-1
+    - mountPath: /etc/pki/tls/cert.pem
+      name: etc-pki-tls-cert.pem-host-2
+      readOnly: true
+    - mountPath: /sys
+      name: sys-host-3
+    - mountPath: /dev/log
+      name: dev-log-host-4
+    - mountPath: /lib/modules
+      name: lib-modules-host-5
+      readOnly: true
+    - mountPath: /var/lib/iscsi
+      name: var-lib-iscsi-host-6
+    - mountPath: /etc/hosts
+      name: etc-hosts-host-7
+      readOnly: true
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-8
+      readOnly: true
+    - mountPath: /etc/pki/tls/certs/ca-bundle.crt
+      name: etc-pki-tls-certs-ca-bundle.crt-host-9
+      readOnly: true
+    - mountPath: /etc/pki/tls/certs/ca-bundle.trust.crt
+      name: etc-pki-tls-certs-ca-bundle.trust.crt-host-10
+      readOnly: true
+    - mountPath: /etc/pki/ca-trust/extracted
+      name: etc-pki-ca-trust-extracted-host-11
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-iscsid.json-host-12
+      readOnly: true
+    - mountPath: /etc/iscsi
+      name: etc-iscsi-host-13
+    - mountPath: /run
+      name: run-host-14
+    - mountPath: /dev
+      name: dev-host-15
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-iscsid-host-16
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/pki/ca-trust/source/anchors
+      type: Directory
+    name: etc-pki-ca-trust-source-anchors-host-0
+  - hostPath:
+      path: /etc/target
+      type: Directory
+    name: etc-target-host-1
+  - hostPath:
+      path: /etc/pki/tls/cert.pem
+      type: File
+    name: etc-pki-tls-cert.pem-host-2
+  - hostPath:
+      path: /sys
+      type: Directory
+    name: sys-host-3
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-4
+  - hostPath:
+      path: /lib/modules
+      type: Directory
+    name: lib-modules-host-5
+  - hostPath:
+      path: /var/lib/iscsi
+      type: Directory
+    name: var-lib-iscsi-host-6
+  - hostPath:
+      path: /etc/hosts
+      type: File
+    name: etc-hosts-host-7
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-8
+  - hostPath:
+      path: /etc/pki/tls/certs/ca-bundle.crt
+      type: File
+    name: etc-pki-tls-certs-ca-bundle.crt-host-9
+  - hostPath:
+      path: /etc/pki/tls/certs/ca-bundle.trust.crt
+      type: File
+    name: etc-pki-tls-certs-ca-bundle.trust.crt-host-10
+  - hostPath:
+      path: /etc/pki/ca-trust/extracted
+      type: Directory
+    name: etc-pki-ca-trust-extracted-host-11
+  - hostPath:
+      path: /var/lib/kolla/config_files/iscsid.json
+      type: File
+    name: var-lib-kolla-config_files-iscsid.json-host-12
+  - hostPath:
+      path: /etc/iscsi
+      type: Directory
+    name: etc-iscsi-host-13
+  - hostPath:
+      path: /run
+      type: Directory
+    name: run-host-14
+  - hostPath:
+      path: /dev
+      type: Directory
+    name: dev-host-15
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/iscsid
+      type: Directory
+    name: var-lib-openstack-healthchecks-iscsid-host-16

--- a/bootc/embedded-services/quadlets/logrotate_crond/logrotate_crond.image
+++ b/bootc/embedded-services/quadlets/logrotate_crond/logrotate_crond.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@logrotate_crond.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-cron:current-podified

--- a/bootc/embedded-services/quadlets/logrotate_crond/logrotate_crond.yaml
+++ b/bootc/embedded-services/quadlets/logrotate_crond/logrotate_crond.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/healthchecks/logrotate_crond:z
+  labels:
+    app: logrotatecrond
+  name: logrotatecrond
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    - name: EDPM_CONFIG_HASH
+      value: dbeb85a6e8c49962f43cd1b33d267c56e4fc2875277fdec63dde667651963664
+    image: quay.io/podified-antelope-centos9/openstack-cron@sha256:5de2a89383bc83899cd33f2c3a972916aee49d47c3fb02dd0f1b71245de219ab
+    name: logrotatecrond
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /etc/pki/ca-trust/source/anchors
+      name: etc-pki-ca-trust-source-anchors-host-0
+      readOnly: true
+    - mountPath: /etc/pki/tls/certs/ca-bundle.trust.crt
+      name: etc-pki-tls-certs-ca-bundle.trust.crt-host-1
+      readOnly: true
+    - mountPath: /dev/log
+      name: dev-log-host-2
+    - mountPath: /var/lib/kolla/config_files/src
+      name: var-lib-config-data-ansible-generated-crond-host-3
+      readOnly: true
+    - mountPath: /var/log/containers
+      name: var-log-containers-host-4
+    - mountPath: /etc/pki/ca-trust/extracted
+      name: etc-pki-ca-trust-extracted-host-5
+      readOnly: true
+    - mountPath: /etc/pki/tls/certs/ca-bundle.crt
+      name: etc-pki-tls-certs-ca-bundle.crt-host-6
+      readOnly: true
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-7
+      readOnly: true
+    - mountPath: /etc/pki/tls/cert.pem
+      name: etc-pki-tls-cert.pem-host-8
+      readOnly: true
+    - mountPath: /etc/hosts
+      name: etc-hosts-host-9
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-logrotate_crond.json-host-10
+      readOnly: true
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-logrotate_crond-host-11
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /etc/pki/ca-trust/source/anchors
+      type: Directory
+    name: etc-pki-ca-trust-source-anchors-host-0
+  - hostPath:
+      path: /etc/pki/tls/certs/ca-bundle.trust.crt
+      type: File
+    name: etc-pki-tls-certs-ca-bundle.trust.crt-host-1
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-2
+  - hostPath:
+      path: /var/lib/config-data/ansible-generated/crond
+      type: Directory
+    name: var-lib-config-data-ansible-generated-crond-host-3
+  - hostPath:
+      path: /var/log/containers
+      type: Directory
+    name: var-log-containers-host-4
+  - hostPath:
+      path: /etc/pki/ca-trust/extracted
+      type: Directory
+    name: etc-pki-ca-trust-extracted-host-5
+  - hostPath:
+      path: /etc/pki/tls/certs/ca-bundle.crt
+      type: File
+    name: etc-pki-tls-certs-ca-bundle.crt-host-6
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-7
+  - hostPath:
+      path: /etc/pki/tls/cert.pem
+      type: File
+    name: etc-pki-tls-cert.pem-host-8
+  - hostPath:
+      path: /etc/hosts
+      type: File
+    name: etc-hosts-host-9
+  - hostPath:
+      path: /var/lib/kolla/config_files/logrotate_crond.json
+      type: File
+    name: var-lib-kolla-config_files-logrotate_crond.json-host-10
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/logrotate_crond
+      type: Directory
+    name: var-lib-openstack-healthchecks-logrotate_crond-host-11

--- a/bootc/embedded-services/quadlets/multipathd/multipathd.image
+++ b/bootc/embedded-services/quadlets/multipathd/multipathd.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@multipathd.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-multipathd:current-podified

--- a/bootc/embedded-services/quadlets/multipathd/multipathd.yaml
+++ b/bootc/embedded-services/quadlets/multipathd/multipathd.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /etc/multipath:z
+  labels:
+    app: multipathd
+  name: multipathd
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    image: quay.io/podified-antelope-centos9/openstack-multipathd@sha256:f0c544406fec8c01bd49727983124d5b43165b71667df2381d68669cf71b2c19
+    name: multipathd
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /var/lib/iscsi
+      name: var-lib-iscsi-host-0
+    - mountPath: /etc/iscsi
+      name: etc-iscsi-host-1
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-multipathd.json-host-2
+      readOnly: true
+    - mountPath: /etc/pki/ca-trust/source/anchors
+      name: etc-pki-ca-trust-source-anchors-host-3
+      readOnly: true
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-multipathd-host-4
+      readOnly: true
+    - mountPath: /dev
+      name: dev-host-5
+    - mountPath: /etc/multipath
+      name: etc-multipath-host-6
+    - mountPath: /etc/hosts
+      name: etc-hosts-host-7
+      readOnly: true
+    - mountPath: /etc/pki/tls/certs/ca-bundle.trust.crt
+      name: etc-pki-tls-certs-ca-bundle.trust.crt-host-8
+      readOnly: true
+    - mountPath: /etc/multipath.conf
+      name: etc-multipath.conf-host-9
+      readOnly: true
+    - mountPath: /dev/log
+      name: dev-log-host-10
+    - mountPath: /lib/modules
+      name: lib-modules-host-11
+      readOnly: true
+    - mountPath: /sys
+      name: sys-host-12
+    - mountPath: /run/udev
+      name: run-udev-host-13
+    - mountPath: /etc/pki/tls/certs/ca-bundle.crt
+      name: etc-pki-tls-certs-ca-bundle.crt-host-14
+      readOnly: true
+    - mountPath: /etc/pki/ca-trust/extracted
+      name: etc-pki-ca-trust-extracted-host-15
+      readOnly: true
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-16
+      readOnly: true
+    - mountPath: /etc/pki/tls/cert.pem
+      name: etc-pki-tls-cert.pem-host-17
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /var/lib/iscsi
+      type: Directory
+    name: var-lib-iscsi-host-0
+  - hostPath:
+      path: /etc/iscsi
+      type: Directory
+    name: etc-iscsi-host-1
+  - hostPath:
+      path: /var/lib/kolla/config_files/multipathd.json
+      type: File
+    name: var-lib-kolla-config_files-multipathd.json-host-2
+  - hostPath:
+      path: /etc/pki/ca-trust/source/anchors
+      type: Directory
+    name: etc-pki-ca-trust-source-anchors-host-3
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/multipathd
+      type: Directory
+    name: var-lib-openstack-healthchecks-multipathd-host-4
+  - hostPath:
+      path: /dev
+      type: Directory
+    name: dev-host-5
+  - hostPath:
+      path: /etc/multipath
+      type: Directory
+    name: etc-multipath-host-6
+  - hostPath:
+      path: /etc/hosts
+      type: File
+    name: etc-hosts-host-7
+  - hostPath:
+      path: /etc/pki/tls/certs/ca-bundle.trust.crt
+      type: File
+    name: etc-pki-tls-certs-ca-bundle.trust.crt-host-8
+  - hostPath:
+      path: /etc/multipath.conf
+      type: File
+    name: etc-multipath.conf-host-9
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-10
+  - hostPath:
+      path: /lib/modules
+      type: Directory
+    name: lib-modules-host-11
+  - hostPath:
+      path: /sys
+      type: Directory
+    name: sys-host-12
+  - hostPath:
+      path: /run/udev
+      type: Directory
+    name: run-udev-host-13
+  - hostPath:
+      path: /etc/pki/tls/certs/ca-bundle.crt
+      type: File
+    name: etc-pki-tls-certs-ca-bundle.crt-host-14
+  - hostPath:
+      path: /etc/pki/ca-trust/extracted
+      type: Directory
+    name: etc-pki-ca-trust-extracted-host-15
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-16
+  - hostPath:
+      path: /etc/pki/tls/cert.pem
+      type: File
+    name: etc-pki-tls-cert.pem-host-17

--- a/bootc/embedded-services/quadlets/nova_compute/nova_compute.image
+++ b/bootc/embedded-services/quadlets/nova_compute/nova_compute.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@nova_compute.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified

--- a/bootc/embedded-services/quadlets/nova_compute/nova_compute.yaml
+++ b/bootc/embedded-services/quadlets/nova_compute/nova_compute.yaml
@@ -8,6 +8,40 @@ metadata:
     app: novacompute
   name: novacompute
 spec:
+  initContainers:
+  - args:
+    - bash
+    - -c
+    - $*
+    - --
+    - eval
+    - python3
+    - /sbin/nova_statedir_ownership.py
+    - '|'
+    - logger
+    - -t
+    - nova_compute_init
+    env:
+    - name: NOVA_STATEDIR_OWNERSHIP_SKIP
+      value: /var/lib/nova/compute_id
+    - name: __OS_DEBUG
+      value: "False"
+    image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+    name: novacomputeinit
+    securityContext:
+      runAsGroup: 0
+      runAsUser: 0
+      seLinuxOptions:
+        type: spc_t
+    volumeMounts:
+    - mountPath: /var/lib/_nova_secontext
+      name: var-lib-_nova_secontext-host-0
+    - mountPath: /sbin/nova_statedir_ownership.py
+      name: var-lib-openstack-config-nova-nova_statedir_ownership.py-host-1
+    - mountPath: /dev/log
+      name: dev-log-host-2
+    - mountPath: /var/lib/nova
+      name: var-lib-nova-host-3
   containers:
   - args:
     - kolla_start
@@ -62,6 +96,14 @@ spec:
       readOnly: true
   hostNetwork: true
   volumes:
+  - hostPath:
+      path: /var/lib/_nova_secontext
+      type: Directory
+    name: var-lib-_nova_secontext-host-0
+  - hostPath:
+      path: /var/lib/openstack/config/nova/nova_statedir_ownership.py
+      type: File
+    name: var-lib-openstack-config-nova-nova_statedir_ownership.py-host-1
   - hostPath:
       path: /var/lib/iscsi
       type: Directory
@@ -126,3 +168,11 @@ spec:
       path: /var/lib/openstack/config/ceph
       type: Directory
     name: var-lib-openstack-config-ceph-host-15
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-2
+  - hostPath:
+      path: /var/lib/nova
+      type: Directory
+    name: var-lib-nova-host-3

--- a/bootc/embedded-services/quadlets/nova_compute/nova_compute.yaml
+++ b/bootc/embedded-services/quadlets/nova_compute/nova_compute.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/cacerts/nova/tls-ca-bundle.pem:z
+  labels:
+    app: novacompute
+  name: novacompute
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    image: quay.io/podified-antelope-centos9/openstack-nova-compute@sha256:3af743aafb3147b3d71d1ef86bc59cb0f778058040f2ac3941d4635557030275
+    name: novacompute
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /var/lib/iscsi
+      name: var-lib-iscsi-host-0
+    - mountPath: /etc/multipath
+      name: etc-multipath-host-1
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-2
+      readOnly: true
+    - mountPath: /run/libvirt
+      name: run-libvirt-host-3
+    - mountPath: /var/lib/libvirt
+      name: var-lib-libvirt-host-4
+    - mountPath: /var/log/containers/nova
+      name: var-log-containers-nova-host-5
+    - mountPath: /etc/ssh/ssh_known_hosts
+      name: etc-ssh-ssh_known_hosts-host-6
+      readOnly: true
+    - mountPath: /lib/modules
+      name: lib-modules-host-7
+      readOnly: true
+    - mountPath: /var/lib/nova
+      name: var-lib-nova-host-8
+    - mountPath: /etc/nvme
+      name: etc-nvme-host-9
+    - mountPath: /etc/multipath.conf
+      name: etc-multipath.conf-host-10
+      readOnly: true
+    - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      name: var-lib-openstack-cacerts-nova-tls-ca-bundle.pem-host-11
+      readOnly: true
+    - mountPath: /etc/iscsi
+      name: etc-iscsi-host-12
+      readOnly: true
+    - mountPath: /dev
+      name: dev-host-13
+    - mountPath: /var/lib/kolla/config_files
+      name: var-lib-openstack-config-nova-host-14
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/ceph
+      name: var-lib-openstack-config-ceph-host-15
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /var/lib/iscsi
+      type: Directory
+    name: var-lib-iscsi-host-0
+  - hostPath:
+      path: /etc/multipath
+      type: Directory
+    name: etc-multipath-host-1
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-2
+  - hostPath:
+      path: /run/libvirt
+      type: Directory
+    name: run-libvirt-host-3
+  - hostPath:
+      path: /var/lib/libvirt
+      type: Directory
+    name: var-lib-libvirt-host-4
+  - hostPath:
+      path: /var/log/containers/nova
+      type: Directory
+    name: var-log-containers-nova-host-5
+  - hostPath:
+      path: /etc/ssh/ssh_known_hosts
+      type: File
+    name: etc-ssh-ssh_known_hosts-host-6
+  - hostPath:
+      path: /lib/modules
+      type: Directory
+    name: lib-modules-host-7
+  - hostPath:
+      path: /var/lib/nova
+      type: Directory
+    name: var-lib-nova-host-8
+  - hostPath:
+      path: /etc/nvme
+      type: Directory
+    name: etc-nvme-host-9
+  - hostPath:
+      path: /etc/multipath.conf
+      type: File
+    name: etc-multipath.conf-host-10
+  - hostPath:
+      path: /var/lib/openstack/cacerts/nova/tls-ca-bundle.pem
+      type: File
+    name: var-lib-openstack-cacerts-nova-tls-ca-bundle.pem-host-11
+  - hostPath:
+      path: /etc/iscsi
+      type: Directory
+    name: etc-iscsi-host-12
+  - hostPath:
+      path: /dev
+      type: Directory
+    name: dev-host-13
+  - hostPath:
+      path: /var/lib/openstack/config/nova
+      type: Directory
+    name: var-lib-openstack-config-nova-host-14
+  - hostPath:
+      path: /var/lib/openstack/config/ceph
+      type: Directory
+    name: var-lib-openstack-config-ceph-host-15

--- a/bootc/embedded-services/quadlets/ovn-controller/ovn_controller.image
+++ b/bootc/embedded-services/quadlets/ovn-controller/ovn_controller.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@ovn_controller.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified

--- a/bootc/embedded-services/quadlets/ovn-controller/ovn_controller.yaml
+++ b/bootc/embedded-services/quadlets/ovn-controller/ovn_controller.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/certs/ovn/default/ca.crt:z
+  creationTimestamp: "2024-12-09T03:34:08Z"
+  labels:
+    app: ovncontroller-pod
+  name: ovncontroller-pod
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    image: quay.io/podified-antelope-centos9/openstack-ovn-controller@sha256:c0c7135732dc7c94794a59c436636854f6cf37de38a6fe74f1a4e5b334ddaa03
+    name: ovncontroller
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-ovn_controller.json-host-0
+      readOnly: true
+    - mountPath: /etc/pki/tls/private/ovndb.key
+      name: var-lib-openstack-certs-ovn-default-tls.key-host-1
+      readOnly: true
+    - mountPath: /run
+      name: run-host-2
+    - mountPath: /run/ovn
+      name: var-lib-openvswitch-ovn-host-3
+    - mountPath: /etc/pki/tls/certs/ovndb.crt
+      name: var-lib-openstack-certs-ovn-default-tls.crt-host-4
+      readOnly: true
+    - mountPath: /lib/modules
+      name: lib-modules-host-5
+      readOnly: true
+    - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      name: var-lib-openstack-cacerts-ovn-tls-ca-bundle.pem-host-6
+      readOnly: true
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-ovn_controller-host-7
+      readOnly: true
+    - mountPath: /etc/pki/tls/certs/ovndbca.crt
+      name: var-lib-openstack-certs-ovn-default-ca.crt-host-8
+      readOnly: true
+  hostNetwork: true
+  hostname: edpm-compute-0
+  volumes:
+  - hostPath:
+      path: /var/lib/kolla/config_files/ovn_controller.json
+      type: File
+    name: var-lib-kolla-config_files-ovn_controller.json-host-0
+  - hostPath:
+      path: /var/lib/openstack/certs/ovn/default/tls.key
+      type: File
+    name: var-lib-openstack-certs-ovn-default-tls.key-host-1
+  - hostPath:
+      path: /run
+      type: Directory
+    name: run-host-2
+  - hostPath:
+      path: /var/lib/openvswitch/ovn
+      type: Directory
+    name: var-lib-openvswitch-ovn-host-3
+  - hostPath:
+      path: /var/lib/openstack/certs/ovn/default/tls.crt
+      type: File
+    name: var-lib-openstack-certs-ovn-default-tls.crt-host-4
+  - hostPath:
+      path: /lib/modules
+      type: Directory
+    name: lib-modules-host-5
+  - hostPath:
+      path: /var/lib/openstack/cacerts/ovn/tls-ca-bundle.pem
+      type: File
+    name: var-lib-openstack-cacerts-ovn-tls-ca-bundle.pem-host-6
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/ovn_controller
+      type: Directory
+    name: var-lib-openstack-healthchecks-ovn_controller-host-7
+  - hostPath:
+      path: /var/lib/openstack/certs/ovn/default/ca.crt
+      type: File
+    name: var-lib-openstack-certs-ovn-default-ca.crt-host-8
+

--- a/bootc/embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.image
+++ b/bootc/embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@ovn_metadata_agent.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified

--- a/bootc/embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.yaml
+++ b/bootc/embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/certs/neutron-metadata/default/tls.crt:z
+  labels:
+    app: ovnmetadataagent
+  name: ovnmetadataagent
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    - name: EDPM_CONFIG_HASH
+      value: c661c16705cc829f2e51e2cb6f2adca1d433ec4966d0205ba7d64f55e7f8fd97
+    image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn@sha256:3c831bff1724d723fde6b58dc47def1a859168a3781f60da5473c91da5bd2a53
+    name: ovnmetadataagent
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+      runAsGroup: 0
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /etc/pki/tls/certs/ovndb.crt
+      name: var-lib-openstack-certs-neutron-metadata-default-tls.crt-host-0
+      readOnly: true
+    - mountPath: /run/netns
+      name: run-netns-host-1
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-ovn_metadata_agent.json-host-2
+      readOnly: true
+    - mountPath: /etc/neutron/kill_scripts
+      name: var-lib-neutron-kill_scripts-host-3
+      readOnly: true
+    - mountPath: /run/openvswitch
+      name: run-openvswitch-host-4
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-ovn_metadata_agent-host-5
+      readOnly: true
+    - mountPath: /etc/neutron.conf.d
+      name: var-lib-config-data-ansible-generated-neutron-ovn-metadata-agent-host-6
+    - mountPath: /var/lib/neutron
+      name: var-lib-neutron-host-7
+    - mountPath: /usr/local/bin/haproxy
+      name: var-lib-neutron-ovn_metadata_haproxy_wrapper-host-8
+      readOnly: true
+    - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      name: var-lib-openstack-cacerts-neutron-metadata-tls-ca-bundle.pem-host-9
+      readOnly: true
+    - mountPath: /etc/pki/tls/certs/ovndbca.crt
+      name: var-lib-openstack-certs-neutron-metadata-default-ca.crt-host-10
+      readOnly: true
+    - mountPath: /etc/pki/tls/private/ovndb.key
+      name: var-lib-openstack-certs-neutron-metadata-default-tls.key-host-11
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /var/lib/openstack/certs/neutron-metadata/default/tls.crt
+      type: File
+    name: var-lib-openstack-certs-neutron-metadata-default-tls.crt-host-0
+  - hostPath:
+      path: /run/netns
+      type: Directory
+    name: run-netns-host-1
+  - hostPath:
+      path: /var/lib/kolla/config_files/ovn_metadata_agent.json
+      type: File
+    name: var-lib-kolla-config_files-ovn_metadata_agent.json-host-2
+  - hostPath:
+      path: /var/lib/neutron/kill_scripts
+      type: Directory
+    name: var-lib-neutron-kill_scripts-host-3
+  - hostPath:
+      path: /run/openvswitch
+      type: Directory
+    name: run-openvswitch-host-4
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/ovn_metadata_agent
+      type: Directory
+    name: var-lib-openstack-healthchecks-ovn_metadata_agent-host-5
+  - hostPath:
+      path: /var/lib/config-data/ansible-generated/neutron-ovn-metadata-agent
+      type: Directory
+    name: var-lib-config-data-ansible-generated-neutron-ovn-metadata-agent-host-6
+  - hostPath:
+      path: /var/lib/neutron
+      type: Directory
+    name: var-lib-neutron-host-7
+  - hostPath:
+      path: /var/lib/neutron/ovn_metadata_haproxy_wrapper
+      type: File
+    name: var-lib-neutron-ovn_metadata_haproxy_wrapper-host-8
+  - hostPath:
+      path: /var/lib/openstack/cacerts/neutron-metadata/tls-ca-bundle.pem
+      type: File
+    name: var-lib-openstack-cacerts-neutron-metadata-tls-ca-bundle.pem-host-9
+  - hostPath:
+      path: /var/lib/openstack/certs/neutron-metadata/default/ca.crt
+      type: File
+    name: var-lib-openstack-certs-neutron-metadata-default-ca.crt-host-10
+  - hostPath:
+      path: /var/lib/openstack/certs/neutron-metadata/default/tls.key
+      type: File
+    name: var-lib-openstack-certs-neutron-metadata-default-tls.key-host-11

--- a/bootc/embedded-services/quadlets/systemd/service-template.kube
+++ b/bootc/embedded-services/quadlets/systemd/service-template.kube
@@ -1,0 +1,11 @@
+[Unit]
+Description=%i container
+After=edpm-container-shutdown.service
+After=openvswitch.service
+Wants=openvswitch.service
+
+[Kube]
+Yaml=/usr/share/containers/systemd/%i.yaml
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This change adds logically bound images for use with bootc. This is implementing based on: https://containers.github.io/bootc/logically-bound-images.html