### PR TITLE
Add bootc fact to container

### DIFF
--- a/bootc/Containerfile.centos9
+++ b/bootc/Containerfile.centos9
@@ -4,34 +4,38 @@ RUN rm -rf /etc/yum.repos.d/*.repo
 COPY output/yum.repos.d /etc/yum.repos.d
 
 ARG PACKAGES="\
-bind-utils \
-buildah \
-cephadm \
-chrony \
-cloud-init \
-crudini \
-crypto-policies-scripts \
-device-mapper-multipath \
-driverctl \
-grubby \
-iproute-tc \
-iptables-services \
-iscsi-initiator-utils \
-jq \
-lvm2 \
-nftables \
-numactl \
-openssh-server \
-openstack-selinux \
-openvswitch \
-os-net-config \
-podman \
-python3-libselinux \
-python3-pyyaml \
-rsync \
-tmpwatch \
-tuned-profiles-cpu-partitioning \
-sysstat"
+	bind-utils \
+	buildah \
+	cephadm \
+	chrony \
+	cloud-init \
+	crudini \
+	crypto-policies-scripts \
+	device-mapper-multipath \
+	driverctl \
+	grubby \
+	iproute-tc \
+	iptables-services \
+	iscsi-initiator-utils \
+	jq \
+	lvm2 \
+	nftables \
+	numactl \
+	openssh-server \
+	openstack-selinux \
+	openvswitch \
+	os-net-config \
+	podman \
+	python3-libselinux \
+	python3-pyyaml \
+	rsync \
+	tmpwatch \
+	tuned-profiles-cpu-partitioning \
+	sysstat"
 ARG ENABLE_UNITS="openvswitch"
 
 RUN dnf -y update && dnf -y install $PACKAGES && dnf clean all && systemctl enable $ENABLE_UNITS
+
+# Drop Ansible fact into place
+COPY ansible-facts/bootc.fact /usr/etc/ansible/facts.d/bootc.fact
+RUN chmod +x /usr/etc/ansible/facts.d/bootc.fact

--- a/bootc/ansible-facts/bootc.fact
+++ b/bootc/ansible-facts/bootc.fact
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+BOOTC_SYSTEM="false"
+
+is_bootc() {
+  BOOTC_STATUS=$(sudo bootc status --json | jq .status.type)
+  if [[ "$BOOTC_STATUS" == \"bootcHost\" ]]; then
+     BOOTC_SYSTEM="true"
+  fi
+}
+
+is_bootc
+
+echo ${BOOTC_SYSTEM}


### PR DESCRIPTION
This change adds a local custom fact to the image that we will reference during the Ansible executions to determine whether we're running on a image-mode node or a normal RHEL / CentOS node.