### PR TITLE
Drop dnf update from edpm-bootc build

### DIFF
--- a/bootc/Containerfile.centos9
+++ b/bootc/Containerfile.centos9
@@ -34,7 +34,7 @@ ARG PACKAGES="\
 	sysstat"
 ARG ENABLE_UNITS="openvswitch"
 
-RUN dnf -y update && dnf -y install $PACKAGES && dnf clean all && systemctl enable $ENABLE_UNITS
+RUN dnf -y install $PACKAGES && dnf clean all && systemctl enable $ENABLE_UNITS
 
 # Drop Ansible fact into place
 COPY ansible-facts/bootc.fact /usr/etc/ansible/facts.d/bootc.fact


### PR DESCRIPTION
Some instability has been observed when using dnf update in the
edpm-bootc image build. Better to just start with the latest available
upstream bootc image. The bootc docs also caution against using dnf
update:

https://docs.fedoraproject.org/en-US/bootc/building-containers/#_dnf_y_update

Signed-off-by: James Slagle <jslagle@redhat.com>
