### PR TITLE
Add packages to bootc image

### DIFF
--- a/bootc/Containerfile.centos9
+++ b/bootc/Containerfile.centos9
@@ -4,37 +4,44 @@ RUN rm -rf /etc/yum.repos.d/*.repo
 COPY output/yum.repos.d /etc/yum.repos.d
 
 ARG PACKAGES="\
-	bind-utils \
-	buildah \
-	cephadm \
-	chrony \
-	cloud-init \
-	crudini \
-	crypto-policies-scripts \
-	device-mapper-multipath \
-	driverctl \
-	grubby \
-	iproute-tc \
-	iptables-services \
-	iscsi-initiator-utils \
-	jq \
-	lvm2 \
-	nftables \
-	numactl \
-	openssh-server \
-	openstack-selinux \
-	openvswitch \
-	os-net-config \
-	podman \
-	python3-libselinux \
-	python3-pyyaml \
-	rsync \
-	tmpwatch \
-	tuned-profiles-cpu-partitioning \
-	sysstat"
+    bind-utils \
+    buildah \
+    cephadm \
+    chrony \
+    cloud-init \
+    cronie \
+    crudini \
+    crypto-policies-scripts \
+    device-mapper-multipath \
+    driverctl \
+    grubby \
+    iproute-tc \
+    iptables-services \
+    iscsi-initiator-utils \
+    jq \
+    lvm2 \
+    nftables \
+    numactl \
+    openssh-server \
+    openstack-network-scripts \
+    openstack-selinux \
+    openvswitch \
+    os-net-config \
+    podman \
+    python3-libselinux \
+    python3-pyyaml \
+    rsync \
+    tmpwatch \
+    tuned-profiles-cpu-partitioning \
+    sysstat"
 ARG ENABLE_UNITS="openvswitch"
 
 RUN dnf -y install $PACKAGES && dnf clean all && systemctl enable $ENABLE_UNITS
+
+# Workaround openstack-network-scripts failing to run update-alternatives
+# See https://issues.redhat.com/browse/OSPRH-13141
+RUN ln -s /etc/sysconfig/network-scripts/ifup /usr/sbin/ifup
+RUN ln -s /etc/sysconfig/network-scripts/ifdown /usr/sbin/ifdown
 
 # Drop Ansible fact into place
 COPY ansible-facts/bootc.fact /usr/etc/ansible/facts.d/bootc.fact


### PR DESCRIPTION
Add packages to bootc image

These packages are added to the bootc image build as they are expected
to be present by edpm-ansible:
- cronie (edpm_logrotate_crond)
- openstack-network-scripts (edpm_network_config / os-net-config)

Also replace tabs with spaces.

Signed-off-by: James Slagle <jslagle@redhat.com>
