### PR TITLE
Add yum-utils to bootc image

### DIFF
--- a/bootc/Containerfile.centos9
+++ b/bootc/Containerfile.centos9
@@ -33,7 +33,9 @@ ARG PACKAGES="\
     rsync \
     tmpwatch \
     tuned-profiles-cpu-partitioning \
-    sysstat"
+    sysstat \
+    yum-utils \
+    "
 ARG ENABLE_UNITS="openvswitch"
 
 RUN dnf -y install $PACKAGES && dnf clean all && systemctl enable $ENABLE_UNITS


### PR DESCRIPTION
The edpm_reboot role uses needs-restarting from yum-utils, so it needs
to be installed in the bootc image.

Signed-off-by: James Slagle <jslagle@redhat.com>
