### PR TITLE
Update edpm-bootc workflow

### DIFF
--- a/.github/workflows/edpm-bootc.yaml
+++ b/.github/workflows/edpm-bootc.yaml
@@ -6,12 +6,18 @@ on:
       - '*'
     paths:
       - bootc/**
+      - .github/workflows/edpm-bootc.yaml
   workflow_dispatch:
 
 env:
   imageregistry: 'quay.io'
   imagenamespace: ${{ secrets.IMAGENAMESPACE || secrets.QUAY_USERNAME }}
   latesttag: latest
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./bootc
 
 jobs:
 
@@ -40,16 +46,14 @@ jobs:
 
     - name: Set latest tag for non main branch
       if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
-      shell: bash
       run: |
         echo "latesttag=${{ steps.branch-name.outputs.current_branch }}-latest" >> $GITHUB_ENV
 
     - name: Build edpm-bootc
       id: build-edpm-bootc
-      shell: bash
       run: |
-        cd bootc
         export EDPM_BOOTC_TAG=${latesttag}
+        podman run --rm -it -v .:/bootc:rw,z quay.io/centos/centos:stream9 /bin/bash -c "cd bootc; dnf -y install make; make output/yum.repos.d"
         make build
 
     - name: Push edpm-bootc To ${{ env.imageregistry }}
@@ -63,7 +67,6 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
 
     - name: Print image url and digest
-      shell: bash
       run: |
         echo "Image pushed to ${{ steps.push-edpm-bootc.outputs.registry-paths }}"
         echo "Image digest: ${{ steps.push-edpm-bootc.outputs.digest }}"

--- a/bootc/Makefile
+++ b/bootc/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 EDPM_BOOTC_REPO ?= quay.io/openstack-k8s-operators/edpm-bootc
 EDPM_BOOTC_TAG ?= latest
 EDPM_CONTAINERFILE ?= Containerfile.centos9


### PR DESCRIPTION
Use bash shell everywhere, including in the Makefile, since it would be
used in the github workflow.

Use podman to run the output/yum.repos.d target since running that
natively on the github workflow ubuntu runner would not work (no dnf
avaiable).

Signed-off-by: James Slagle <jslagle@redhat.com>
