### PR TITLE
Move workflow defaults to be under the build and push job

### DIFF
--- a/.github/workflows/edpm-bootc.yaml
+++ b/.github/workflows/edpm-bootc.yaml
@@ -14,11 +14,6 @@ env:
   imagenamespace: ${{ secrets.IMAGENAMESPACE || secrets.QUAY_USERNAME }}
   latesttag: latest
 
-defaults:
-  run:
-    shell: bash
-    working-directory: ./bootc
-
 jobs:
 
   check-secrets:
@@ -36,6 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-secrets]
     if: needs.check-secrets.outputs.have-secrets == 'true'
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./bootc
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
They don't need to apply to the check-secrets job and cause it to fail.

Signed-off-by: James Slagle <jslagle@redhat.com>
