### PR TITLE
Disable bootc automatic update check and reboot

### DIFF
--- a/bootc/Containerfile.centos9
+++ b/bootc/Containerfile.centos9
@@ -65,6 +65,9 @@ RUN ln -s /etc/sysconfig/network-scripts/ifdown /usr/sbin/ifdown
 COPY ansible-facts/bootc.fact /etc/ansible/facts.d/bootc.fact
 RUN chmod +x /etc/ansible/facts.d/bootc.fact
 
+# Disable automatic update check and reboot
+RUN systemctl mask bootc-fetch-apply-updates.timer
+
 # This should be the last command
 # https://docs.fedoraproject.org/en-US/bootc/building-containers/#_linting
 RUN bootc container lint


### PR DESCRIPTION
Mask the systemd timer that continually checks for an update container
image and will apply if one is found as it causes a reboot.

Signed-off-by: James Slagle <jslagle@redhat.com>
