### PR TITLE
Remove libguestfs in line with nova changes

### DIFF
--- a/bootc/Containerfile.centos9
+++ b/bootc/Containerfile.centos9
@@ -45,7 +45,6 @@ ARG LIBVIRT_PACKAGES="\
     libvirt-daemon \
     qemu-kvm \
     qemu-img \
-    libguestfs \
     libseccomp \
     swtpm \
     swtpm-tools \


### PR DESCRIPTION
This change removes the libguestfs package from the bootc container. This is inline with efforts from the Compute team to remove this package from our dataplane nodes:
https://github.com/openstack-k8s-operators/tcib/pull/142/files#diff-20fdbc4b7badc4cdcab1a535614f5d3c52acabf84aba7661ac2e5ead8acc276eR8