### PR TITLE
Bootc: add RHEL support with internal repos and RHSM

### DIFF
--- a/bootc/.gitignore
+++ b/bootc/.gitignore
@@ -1,0 +1,1 @@
+rhsm-custom.sh

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -1,7 +1,5 @@
-FROM quay.io/centos-bootc/centos-bootc:stream9
-
-RUN rm -rf /etc/yum.repos.d/*.repo
-COPY output/yum.repos.d /etc/yum.repos.d
+ARG EDPM_BASE_IMAGE
+FROM $EDPM_BASE_IMAGE
 
 ARG PACKAGES="\
     bind-utils \
@@ -53,7 +51,11 @@ ARG LIBVIRT_PACKAGES="\
     cyrus-sasl-scram \
     "
 
-RUN dnf -y install $PACKAGES $LIBVIRT_PACKAGES && dnf clean all && systemctl enable $ENABLE_UNITS
+RUN dnf -y install $PACKAGES $LIBVIRT_PACKAGES && \
+    dnf clean all && \
+    (subscription-manager remove --all || true) && \
+    (subscription-manager unregister || true) && \
+    systemctl enable $ENABLE_UNITS
 
 # Drop Ansible fact into place
 COPY ansible-facts/bootc.fact /etc/ansible/facts.d/bootc.fact

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -51,7 +51,10 @@ ARG LIBVIRT_PACKAGES="\
     cyrus-sasl-scram \
     "
 
-RUN dnf -y install $PACKAGES $LIBVIRT_PACKAGES && \
+ARG RHSM_SCRIPT=empty.sh
+COPY $RHSM_SCRIPT /var/tmp/rhsm-script.sh
+RUN /var/tmp/rhsm-script.sh && \
+    dnf -y install $PACKAGES $LIBVIRT_PACKAGES && \
     dnf clean all && \
     (subscription-manager remove --all || true) && \
     (subscription-manager unregister || true) && \

--- a/bootc/Makefile
+++ b/bootc/Makefile
@@ -7,6 +7,7 @@ EDPM_BOOTC_IMAGE ?= ${EDPM_BOOTC_REPO}:${EDPM_BOOTC_TAG}
 EDPM_QCOW2_IMAGE ?= ${EDPM_BOOTC_REPO}:${EDPM_BOOTC_TAG}-qcow2
 BUILDER_IMAGE ?= quay.io/centos-bootc/bootc-image-builder:latest
 HOST_PACKAGES ?= podman osbuild-selinux https://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
+RHSM_SCRIPT ?= empty.sh
 
 .ONESHELL:
 
@@ -31,6 +32,7 @@ build: output/yum.repos.d
 	sudo buildah inspect ${EDPM_BOOTC_IMAGE} > /dev/null && exit 0 || true
 	sudo buildah bud \
 		--build-arg EDPM_BASE_IMAGE=${EDPM_BASE_IMAGE} \
+		--build-arg RHSM_SCRIPT=${RHSM_SCRIPT} \
 		--volume /etc/pki/ca-trust:/etc/pki/ca-trust:ro,Z \
 		--volume $(shell pwd)/output/yum.repos.d:/etc/yum.repos.d:rw,Z \
 		-f ${EDPM_CONTAINERFILE} \

--- a/bootc/Makefile
+++ b/bootc/Makefile
@@ -1,16 +1,12 @@
 SHELL := /bin/bash
 EDPM_BOOTC_REPO ?= quay.io/openstack-k8s-operators/edpm-bootc
 EDPM_BOOTC_TAG ?= latest
-EDPM_CONTAINERFILE ?= Containerfile.centos9
+EDPM_CONTAINERFILE ?= Containerfile
+EDPM_BASE_IMAGE ?= quay.io/centos-bootc/centos-bootc:stream9
 EDPM_BOOTC_IMAGE ?= ${EDPM_BOOTC_REPO}:${EDPM_BOOTC_TAG}
 EDPM_QCOW2_IMAGE ?= ${EDPM_BOOTC_REPO}:${EDPM_BOOTC_TAG}-qcow2
 BUILDER_IMAGE ?= quay.io/centos-bootc/bootc-image-builder:latest
-HOST_PACKAGES ?= podman osbuild-selinux
-REPO_SETUP ?= current-podified
-REPO_SETUP_BRANCH ?= master
-REPO_SETUP_DISTRO ?= centos9
-REPO_SETUP_DISTRO_MIRROR ?=
-REPO_SETUP_MIRROR ?= https://trunk.rdoproject.org
+HOST_PACKAGES ?= podman osbuild-selinux https://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
 
 .ONESHELL:
 
@@ -23,25 +19,22 @@ output:
 
 output/repo-setup: output
 	ls output/repo-setup && exit 0 || true
-	cd output
-	curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar xvz
-	cd repo-setup-main
-	python3 -m venv ./venv
-	source ./venv/bin/activate
-	PBR_VERSION=0.0.0 python3 -m pip install ./
-	cp venv/bin/repo-setup ../repo-setup
+	./install-repo-setup.sh
 
 output/yum.repos.d: output/repo-setup
 	ls output/yum.repos.d && exit 0 || true
-	cd output
-	mkdir -p yum.repos.d
-	./repo-setup --output-path yum.repos.d --branch ${REPO_SETUP_BRANCH} --rdo-mirror ${REPO_SETUP_MIRROR} -d ${REPO_SETUP_DISTRO} ${REPO_SETUP}
-
+	mkdir -p output/yum.repos.d
+	./run-repo-setup.sh
 
 .PHONY: build
 build: output/yum.repos.d
 	sudo buildah inspect ${EDPM_BOOTC_IMAGE} > /dev/null && exit 0 || true
-	sudo buildah bud -f ${EDPM_CONTAINERFILE} -t ${EDPM_BOOTC_IMAGE} .
+	sudo buildah bud \
+		--build-arg EDPM_BASE_IMAGE=${EDPM_BASE_IMAGE} \
+		--volume /etc/pki/ca-trust:/etc/pki/ca-trust:ro,Z \
+		--volume $(shell pwd)/output/yum.repos.d:/etc/yum.repos.d:rw,Z \
+		-f ${EDPM_CONTAINERFILE} \
+		-t ${EDPM_BOOTC_IMAGE} .
 
 .PHONY: build-push
 build-push: build

--- a/bootc/README.rst
+++ b/bootc/README.rst
@@ -34,7 +34,24 @@ commands::
     sudo podman login registry.redhat.io
 
     export EDPM_BOOTC_REPO=quay.io/<account>/edpm-bootc
-    export EDPM_BOOTC_TAG=rhel9
+    export EDPM_BOOTC_TAG=rhel9-rhos-release
+    make build
+    sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
+
+To build a RHEL-9.4 based bootc EDPM container using published packages, run
+the following commands::
+
+    # switch to RHEL-9.4 images
+    export BUILDER_IMAGE=registry.redhat.io/rhel9/bootc-image-builder:9.4
+    export EDPM_BASE_IMAGE=registry.redhat.io/rhel9/rhel-bootc:9.4
+
+    # make a custom copy of the subscription-manager script and edit it for
+    # your registration details
+    cp rhsm.sh rhsm-custom.sh
+    export RHSM_SCRIPT=rhsm-custom.sh
+
+    export EDPM_BOOTC_REPO=quay.io/<account>/edpm-bootc
+    export EDPM_BOOTC_TAG=rhel9-rhsm
     make build
     sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
 

--- a/bootc/README.rst
+++ b/bootc/README.rst
@@ -2,12 +2,41 @@
 EDPM bootc image builder
 ========================
 
+Pre-requesites can be installed by running::
+
+    make host-deps
+
 To build a CentOS-9-Stream based bootc EDPM container image, run the following
-command::
+commands::
 
     export EDPM_BOOTC_REPO=quay.io/<account>/edpm-bootc
+    export EDPM_BOOTC_TAG=centos9
     make build
-    sudo podman push $EDPM_BOOTC_REPO:latest
+    sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
+
+To build a RHEL-9.4 based bootc EDPM container image using internal
+repositories, install the required certificates then run the following
+commands::
+
+    # switch to RHEL-9.4 images
+    export BUILDER_IMAGE=registry.redhat.io/rhel9/bootc-image-builder:9.4
+    export EDPM_BASE_IMAGE=registry.redhat.io/rhel9/rhel-bootc:9.4
+
+    # Config to build repository files for internal repos
+    export CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+    export REPO_SETUP_DISTRO=rhel9
+    export REPO_SETUP=current-podified
+    export REPO_SETUP_BRANCH=osp18
+    export REPO_SETUP_MIRROR=<mirror for internal repos>
+    export REPO_SETUP_EXTRA="rhos-release ceph-6.0 -r 9.4 -t yum.repos.d"
+
+    # login to the registry
+    sudo podman login registry.redhat.io
+
+    export EDPM_BOOTC_REPO=quay.io/<account>/edpm-bootc
+    export EDPM_BOOTC_TAG=rhel9
+    make build
+    sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
 
 To convert this container image to ``output/edpm-bootc.qcow2``, run the
 following command::
@@ -18,12 +47,14 @@ To package ``edpm-bootc.qcow2`` inside a container image EDPM baremetal
 deployment, run the following command::
 
     make package
-    sudo podman push $EDPM_BOOTC_REPO:latest-qcow2
+    sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG-qcow2
 
-To deploy EDPM baremetal with this image, customize the ``baremetalSetTemplate`` with::
+To deploy EDPM baremetal with this image, customize the
+``baremetalSetTemplate`` substituting values for ``<EDPM_BOOTC_REPO>`` and
+``<EDPM_BOOTC_TAG>`` ::
 
     kind: OpenStackDataPlaneNodeSet
     spec:
     baremetalSetTemplate:
-        osContainerImageUrl: quay.io/<account>/edpm-bootc:latest-qcow2
+        osContainerImageUrl: <EDPM_BOOTC_REPO>:<EDPM_BOOTC_TAG>-qcow2
         osImage: edpm-bootc.qcow2

--- a/bootc/empty.sh
+++ b/bootc/empty.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# script deliberately left empty

--- a/bootc/install-repo-setup.sh
+++ b/bootc/install-repo-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eux
+
+pushd output
+curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar xvz
+pushd repo-setup-main
+python3 -m venv ./venv
+source ./venv/bin/activate
+PBR_VERSION=0.0.0 python3 -m pip install ./
+cp venv/bin/repo-setup ../repo-setup
+popd
+popd

--- a/bootc/rhsm.sh
+++ b/bootc/rhsm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eux
+
+# Edit RHSM_ values for the subscription configuration
+RHSM_USER=unset
+RHSM_PASSWORD=unset
+RHSM_REPOS="--enable=rhoso-18.0-for-rhel-9-x86_64-rpms \
+            --enable=rhceph-8-tools-for-rhel-9-x86_64-rpms \
+            --enable=fast-datapath-for-rhel-9-x86_64-rpms"
+# Only required when Simple Content Access (SCA) is disabled
+RHSM_POOL=""
+
+rm /etc/yum.repos.d/*.repo
+subscription-manager register --username=$RHSM_USER --password=$RHSM_PASSWORD
+if [ -n "${RHSM_POOL}" ]; then
+    subscription-manager attach --pool=$RHSM_POOL
+fi
+subscription-manager repos $RHSM_REPOS

--- a/bootc/run-repo-setup.sh
+++ b/bootc/run-repo-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eux
+
+REPO_SETUP=${REPO_SETUP:-current-podified}
+REPO_SETUP_BRANCH=${REPO_SETUP_BRANCH:-antelope}
+REPO_SETUP_DISTRO=${REPO_SETUP_DISTRO:-centos9}
+REPO_SETUP_MIRROR=${REPO_SETUP_MIRROR:-https://trunk.rdoproject.org}
+REPO_SETUP_EXTRA=${REPO_SETUP_EXTRA:-echo Done}
+
+pushd output
+./repo-setup --output-path yum.repos.d --branch ${REPO_SETUP_BRANCH} --rdo-mirror ${REPO_SETUP_MIRROR} -d ${REPO_SETUP_DISTRO} ${REPO_SETUP}
+$REPO_SETUP_EXTRA
+popd


### PR DESCRIPTION
This shares a single Containerfile for building an upstream image, and a rhel-9.4 based image using internal repositories.

This allows testing with RHEL based images, and is the first step for end users building their own images with subscription-manager.

/etc/yum.repos.d is now bind-mounted in instead of copying.

It is also possible to build rhel-9.4 based images using subscription-manager to set up the repos.

Documentation to do this is included in the README.rst but the intention
is to write some external documention which will allow end-users to
build this image without a checkout of edpm-image-builder or this
Makefile.

Images with all 3 variants have been published to test with:
quay.io/steveb/edpm-bootc:centos9
quay.io/steveb/edpm-bootc:centos9-qcow2
quay.io/steveb/edpm-bootc:rhel9-rhos-release
quay.io/steveb/edpm-bootc:rhel9-rhos-release-qcow2
quay.io/steveb/edpm-bootc:rhel9-rhsm
quay.io/steveb/edpm-bootc:rhel9-rhsm-qcow2

Issue: [OSPRH-14522](https://issues.redhat.com//browse/OSPRH-14522)
Issue: [OSPRH-14523](https://issues.redhat.com//browse/OSPRH-14523)