### PR TITLE
Add growvols package to bootc image

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -12,6 +12,7 @@ ARG PACKAGES="\
     crypto-policies-scripts \
     device-mapper-multipath \
     driverctl \
+    growvols \
     grubby \
     iproute-tc \
     iptables-services \


### PR DESCRIPTION
Needed by edpm_growvols role

Jira: [OSPRH-11517](https://issues.redhat.com//browse/OSPRH-11517)
Signed-off-by: James Slagle <james.slagle@gmail.com>
