### PR TITLE
Ensure device-mapper-multipath is present

### DIFF
--- a/dib/edpm-base/package-installs.yaml
+++ b/dib/edpm-base/package-installs.yaml
@@ -2,6 +2,7 @@ buildah:
 chrony:
 crudini:
 crypto-policies-scripts:
+device-mapper-multipath:
 driverctl:
 grubby:
 iptables-services:


### PR DESCRIPTION
One "fun" issue which can happen with dib images is a vendor may have built a stock ramdisk from a build farm where the ramdisk had the artifacts to handle multipath usage, but not had the artifacts *inside* of the actual image.

Where things go sideways is when you regenerate the ramdisk with dracut and the newly build ramdisk lacks ramdisk support. This is because the ramdisk building utility uses state and artifacts from the host to incorporate into the artifact. When this occurs, even if you ask for multipath, dracut will not fail if the required additional artifacts are not found.

So the key is to have device-mapper-multipath present, which triggers the related dependency installations which enables rebuilt ramdisks to have the required artifacts for booting from multipath devices to work as expected.

A similar upstream patch was proposed to diskimage-builder, however because of dependencies and requirements, that might not make it downstream in time, so we're patching the actual customization element used for the downstream build as well.

Issue [OSPRH-15887](https://issues.redhat.com//browse/OSPRH-15887)