### PR TITLE
Conditionally enable fips in bootc image

### DIFF
--- a/bootc/01-fips.toml
+++ b/bootc/01-fips.toml
@@ -1,0 +1,2 @@
+# Enable FIPS
+kargs = ["fips=1"]

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -135,6 +135,18 @@ RUN /var/tmp/rhsm-script.sh && \
     (subscription-manager unregister || true) && \
     systemctl enable $ENABLE_UNITS
 
+
+# Configure FIPS
+ARG FIPS=1
+RUN if [ "${FIPS}" = "1" ] ; \
+    then \
+        # Enable the FIPS crypto policy
+        update-crypto-policies --no-reload --set FIPS ; \
+        touch /etc/system-fips ; \
+        mkdir -p /usr/lib/bootc/kargs.d ; \
+        echo -e "# Enable FIPS\nkargs = [\"fips=1\"]\n" > /usr/lib/bootc/kargs.d/01-fips.toml ; \
+    fi
+
 # Drop Ansible fact into place
 COPY ansible-facts/bootc.fact /etc/ansible/facts.d/bootc.fact
 RUN chmod +x /etc/ansible/facts.d/bootc.fact

--- a/bootc/Makefile
+++ b/bootc/Makefile
@@ -8,6 +8,7 @@ EDPM_QCOW2_IMAGE ?= ${EDPM_BOOTC_REPO}:${EDPM_BOOTC_TAG}-qcow2
 BUILDER_IMAGE ?= quay.io/centos-bootc/bootc-image-builder:latest
 HOST_PACKAGES ?= podman osbuild-selinux https://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
 RHSM_SCRIPT ?= empty.sh
+FIPS ?= 1
 
 .ONESHELL:
 
@@ -33,6 +34,7 @@ build: output/yum.repos.d
 	sudo buildah bud \
 		--build-arg EDPM_BASE_IMAGE=${EDPM_BASE_IMAGE} \
 		--build-arg RHSM_SCRIPT=${RHSM_SCRIPT} \
+		--build-arg FIPS=${FIPS} \
 		--volume /etc/pki/ca-trust:/etc/pki/ca-trust:ro,Z \
 		--volume $(shell pwd)/output/yum.repos.d:/etc/yum.repos.d:rw,Z \
 		-f ${EDPM_CONTAINERFILE} \


### PR DESCRIPTION
Conditionally enable fips in bootc image

Since FIPS can't be enabled at runtime in bootc, add an option to enable
it at image build time. Also adds targets to the Makefile to create the
image with FIPS enabled.

Jira: [OSPRH-15967](https://issues.redhat.com//browse/OSPRH-15967)
Signed-off-by: James Slagle <jslagle@redhat.com>

