### PR TITLE
OSPRH-17209: Change the default boot label.

### DIFF
--- a/dib/edpm-partition-uefi/block-device-default.yaml
+++ b/dib/edpm-partition-uefi/block-device-default.yaml
@@ -86,7 +86,7 @@
     name: fs_root
     base: lv_root
     type: xfs
-    label: "img-rootfs"
+    label: "rhoso-rootfs"
     mount:
         mount_point: /
         fstab:


### PR DESCRIPTION
A conflict can occur where storage area networks are utilized for instance storage, where multiple instances might exist on the underlying backend storage, which may conflict with the local disks.

For RHOSO, we want the the intended and expected disk to boot, and *not* any other potential disk.

A such, we've changed the default label moving forward.