### PR TITLE
Add sos package to bootc image build

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -21,6 +21,7 @@ ARG BOOTSTRAP_PACKAGES="\
     crypto-policies-scripts \
     grubby \
     openstack-network-scripts \
+    sos \
     "
 
 # dib/ceph packages


### PR DESCRIPTION
This package was added to edpm_bootstrap in
https://github.com/openstack-k8s-operators/edpm-ansible/pull/980

Signed-off-by: James Slagle <jslagle@redhat.com>
