### PR TITLE
Fix Containerfile name in workflow

### DIFF
--- a/.github/workflows/edpm-bootc.yaml
+++ b/.github/workflows/edpm-bootc.yaml
@@ -67,7 +67,7 @@ jobs:
         image: edpm-bootc
         tags: ${{ env.latesttag }} ${{ github.sha }} ${{ env.podified }}
         containerfiles: |
-          ./bootc/Containerfile.centos9
+          ./bootc/Containerfile
         context: bootc
 
     - name: Push edpm-bootc container image to ${{ env.imageregistry }}


### PR DESCRIPTION
This file was renamed in db6740d0942b0ecb28ce5c3bdf3476ca8cef8544, but
the workflow was never updated and has been broken since then. This
fixes the Containerfile name.

Signed-off-by: James Slagle <jslagle@redhat.com>
