### PR TITLE
Pass volume args to buildah action

### DIFF
--- a/.github/workflows/edpm-bootc.yaml
+++ b/.github/workflows/edpm-bootc.yaml
@@ -69,6 +69,9 @@ jobs:
         tags: ${{ env.latesttag }} ${{ github.sha }} ${{ env.podified }}
         build-args:
           EDPM_BASE_IMAGE=${{ env.EDPM_BASE_IMAGE }}
+        extra-agrs:
+          --volume /etc/pki/ca-trust:/etc/pki/ca-trust:ro,Z \
+          --volume output/yum.repos.d:/etc/yum.repos.d:rw,Z \
         containerfiles: |
           ./bootc/Containerfile
         context: bootc


### PR DESCRIPTION
These volume mounts are needed when building the bootc image.

Signed-off-by: James Slagle <jslagle@redhat.com>
