### PR TITLE
Add dib element to change cloud-init network renderer order

### DIFF
--- a/dib/cloud-init-network-renderer/README.md
+++ b/dib/cloud-init-network-renderer/README.md
@@ -1,0 +1,16 @@
+Configures cloud-init to prefer NetworkManager for network configuration.
+
+This element writes a drop-in at `/etc/cloud/cloud.cfg.d/90-network-manager-renderer.cfg` with:
+
+```yaml
+system_info:
+  network:
+    renderers: ['network-manager', 'sysconfig', 'eni', 'netplan', 'networkd']
+```
+
+This ensures cloud-init uses NetworkManager when available, with `sysconfig` and `netplan` etc as fallbacks.
+
+The renderer list/order can be customized by setting `DIB_CLOUD_INIT_NETWORK_RENDERERS` to a YAML array format, e.g.:
+```bash
+export DIB_CLOUD_INIT_NETWORK_RENDERERS="['netplan', 'sysconfig', 'network-manager']"
+```

--- a/dib/cloud-init-network-renderer/install.d/81-network-renderer
+++ b/dib/cloud-init-network-renderer/install.d/81-network-renderer
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eux
+
+DIB_CLOUD_INIT_NETWORK_RENDERERS=${DIB_CLOUD_INIT_NETWORK_RENDERERS:-['network-manager', 'sysconfig', 'eni', 'netplan', 'networkd']}
+
+mkdir -p /etc/cloud/cloud.cfg.d
+cat > /etc/cloud/cloud.cfg.d/90-network-manager-renderer.cfg <<EOF
+# This file ensures cloud-init prefers NetworkManager for network rendering
+system_info:
+  network:
+    renderers: $DIB_CLOUD_INIT_NETWORK_RENDERERS
+EOF
+chmod 0644 /etc/cloud/cloud.cfg.d/90-network-manager-renderer.cfg

--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -19,6 +19,7 @@
   - interface-names
   - openvswitch
   - override-pip-and-virtualenv
+  - cloud-init-network-renderer
   - remove-resolvconf
   - repo-setup
   min-tmpfs: 7

--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -18,6 +18,7 @@
   - interface-names
   - openvswitch
   - override-pip-and-virtualenv
+  - cloud-init-network-renderer
   - remove-resolvconf
   - repo-setup
   min-tmpfs: 7


### PR DESCRIPTION
Give priority to network-manager as we now enable NetworkManager to update resolv.conf. Otherwise NetworkManager wipes out the dns server from resolv.conf.

jira:  https://issues.redhat.com/browse/OSPRH-19018