### PR TITLE
Fix: bootc.fact returning nil after using rpm-ostree

### DIFF
--- a/bootc/ansible-facts/bootc.fact
+++ b/bootc/ansible-facts/bootc.fact
@@ -14,6 +14,15 @@ is_bootc() {
   BOOTC_STATUS=$(sudo bootc status --json | jq .status.type)
   if [[ "$BOOTC_STATUS" == \"bootcHost\" ]]; then
     BOOTC_SYSTEM="true"
+    return
+  fi
+
+  # Fallback: if bootc status type is set to nil for some reasons like
+  # rpm-ostree install, or bootc is not able to confirm that the system is
+  # not bootc anymore
+  # NOTE: rpm-ostree install should not be allowed in production systems.
+  if [[ -d /sysroot/ostree/bootc ]] || [[ -d /ostree/bootc ]]; then
+    BOOTC_SYSTEM="true"
   fi
 }
 


### PR DESCRIPTION
Jira: [OSPRH-13140](https://issues.redhat.com//browse/OSPRH-13140)

Using rpm-ostree to install a missing package, the bootc.fact for ansible no longer returned true b/c "sudo bootc status --json | jq .status.type" returned nil (the type field was nil).

Further detail in the behavior can be found here - https://github.com/bootc-dev/bootc/issues/347 and Jira description
