### PR TITLE
Remove nodeset suffix

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2,7 +2,7 @@
 - job:
     name: eib-content-provider-build-images
     parent: content-provider-build-images-base
-    nodeset: centos-stream-9-vexxhost
+    nodeset: centos-stream-9
 
 - job:
     name: eib-crc-podified-edpm-baremetal


### PR DESCRIPTION
After removing one of the cloud provider, the nodeset would not contain the suffix that was added to recognize the cloud provider. Since now, we will have just one cloud provider, so keeping the suffix does not make sense.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3852