### PR TITLE
Add CentOS Stream 10 and RHEL 10 image support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,15 +21,26 @@ directory::
 edpm-hardened-uefi
 ------------------
 
-The CentOS-9-Stream version of ``edpm-hardened-uefi.qcow2`` can be built with
-master branch ``current-podified`` by running::
+The ``edpm-hardened-uefi.qcow2`` image supports the following CentOS Stream and
+RHEL releases with master branch ``current-podified``::
 
     diskimage-builder ./images/edpm-hardened-uefi-centos-9-stream.yaml
+    diskimage-builder ./images/edpm-hardened-uefi-centos-10-stream.yaml
+    diskimage-builder ./images/edpm-hardened-uefi-rhel-9.yaml
+    diskimage-builder ./images/edpm-hardened-uefi-rhel-10.yaml
+
+.. note::
+
+   ``current-podified`` is not yet available for CentOS Stream 10. The CI jobs
+   currently use ``current`` until promotion to ``current-podified`` includes
+   the required fixes::
+
+       DIB_REPO_SETUP=current diskimage-builder ./images/edpm-hardened-uefi-centos-10-stream.yaml
 
 To create a FIPS enabled image, add ``edpm-hardened-uefi-fips.yaml`` to
 include the ``fips`` element::
 
-    diskimage-builder ./images/edpm-hardened-uefi-centos-9-stream.yaml ./images/edpm-hardened-uefi-fips.yaml
+    diskimage-builder ./images/edpm-hardened-uefi-centos-10-stream.yaml ./images/edpm-hardened-uefi-fips.yaml
 
 See dib/repo-setup/README.md for environment variables to control which RDO
 repositories to configure.
@@ -47,16 +58,22 @@ It can then be copied out of the container image, for example into
 ironic-python-agent
 -------------------
 
-The CentOS-9-Stream version of ``ironic-python-agent.initramfs`` and
-``ironic-python-agent.kernel`` can be built with master branch
-``current-podified`` by running::
+The ``ironic-python-agent.initramfs`` and ``ironic-python-agent.kernel`` images
+support the following CentOS Stream and RHEL releases with master branch
+``current-podified``::
 
     diskimage-builder ./images/ironic-python-agent-centos-9-stream.yaml
-
-Similarly, the rhel-9 version can be built with master branch
-``current-podified`` by running::
-
+    diskimage-builder ./images/ironic-python-agent-centos-10-stream.yaml
     diskimage-builder ./images/ironic-python-agent-rhel-9.yaml
+    diskimage-builder ./images/ironic-python-agent-rhel-10.yaml
+
+.. note::
+
+   ``current-podified`` is not yet available for CentOS Stream 10. The CI jobs
+   currently use ``current`` until promotion to ``current-podified`` includes
+   the required fixes::
+
+       DIB_REPO_SETUP=current diskimage-builder ./images/ironic-python-agent-centos-10-stream.yaml
 
 ``ironic-python-agent.qcow2`` can be packaged inside a container image for
 distribution by running::

--- a/bootc/README.rst
+++ b/bootc/README.rst
@@ -6,21 +6,33 @@ Pre-requesites can be installed by running::
 
     make host-deps
 
-To build a CentOS-9-Stream based bootc EDPM container image, run the following
-commands::
+The bootc build defaults target CentOS Stream 9. To build a CentOS Stream 10
+based bootc EDPM container image, override the base image and repo-setup distro
+then run the following commands::
 
     export EDPM_BOOTC_REPO=quay.io/<account>/edpm-bootc
-    export EDPM_BOOTC_TAG=centos9
+    export EDPM_BOOTC_TAG=centos10
+    export EDPM_BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream10
+    export REPO_SETUP_DISTRO=centos10
+    export REPO_SETUP_BRANCH=master
+    export REPO_SETUP=podified-ci-testing
     make build
     sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
 
-To build a RHEL-9.4 based bootc EDPM container image using internal
-repositories, install the required certificates then run the following
-commands::
+.. note::
 
-    # switch to RHEL-9.4 images
-    export BUILDER_IMAGE=registry.redhat.io/rhel9/bootc-image-builder:9.4
-    export EDPM_BASE_IMAGE=registry.redhat.io/rhel9/rhel-bootc:9.4
+   ``current-podified`` is not yet available for CentOS Stream 10. The above
+   uses ``podified-ci-testing`` and ``master`` branch until it is.
+
+To continue using CentOS Stream 9, leave the defaults in place and run
+``make build`` (the default tag is ``latest``).
+
+To build a RHEL 9 based bootc EDPM container image using internal repositories,
+install the required certificates then run the following commands::
+
+    # switch to RHEL 9 images
+    export BUILDER_IMAGE=registry.redhat.io/rhel9/bootc-image-builder:latest
+    export EDPM_BASE_IMAGE=registry.redhat.io/rhel9/rhel-bootc:latest
 
     # Config to build repository files for internal repos
     export CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
@@ -38,12 +50,36 @@ commands::
     make build
     sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
 
-To build a RHEL-9.4 based bootc EDPM container using published packages, run
-the following commands::
+To build a RHEL 10 based bootc EDPM container image using internal
+repositories, use the matching RHEL 10 images and repo-setup distro::
 
-    # switch to RHEL-9.4 images
-    export BUILDER_IMAGE=registry.redhat.io/rhel9/bootc-image-builder:9.4
-    export EDPM_BASE_IMAGE=registry.redhat.io/rhel9/rhel-bootc:9.4
+    # switch to RHEL 10 images
+    export BUILDER_IMAGE=registry.redhat.io/rhel10/bootc-image-builder:latest
+    export EDPM_BASE_IMAGE=registry.redhat.io/rhel10/rhel-bootc:latest
+
+    # Config to build repository files for internal repos
+    export CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+    export REPO_SETUP_DISTRO=rhel10
+    export REPO_SETUP=current-podified
+    export REPO_SETUP_BRANCH=osp18
+    export REPO_SETUP_MIRROR=<mirror for internal repos>
+    export REPO_SETUP_EXTRA="rhos-release ceph-6.0 -r 10 -t yum.repos.d"
+
+    # login to the registry
+    sudo podman login registry.redhat.io
+
+    export EDPM_BOOTC_REPO=quay.io/<account>/edpm-bootc
+    export EDPM_BOOTC_TAG=rhel10-rhos-release
+    make build
+    sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
+
+To build a RHEL 9 or RHEL 10 based bootc EDPM container using published
+packages, run the following commands::
+
+    # switch to the matching RHEL bootc images
+    export BUILDER_IMAGE=registry.redhat.io/rhel9/bootc-image-builder:latest
+    export EDPM_BASE_IMAGE=registry.redhat.io/rhel9/rhel-bootc:latest
+    export RHEL_MAJOR=9
 
     # make a custom copy of the subscription-manager script and edit it for
     # your registration details
@@ -54,6 +90,10 @@ the following commands::
     export EDPM_BOOTC_TAG=rhel9-rhsm
     make build
     sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
+
+Set ``RHEL_MAJOR=10`` and switch the ``BUILDER_IMAGE``, ``EDPM_BASE_IMAGE``,
+and ``EDPM_BOOTC_TAG`` values to their ``rhel10`` equivalents to build the
+same image against RHEL 10.
 
 To convert this container image to ``output/edpm-bootc.qcow2``, run the
 following command::

--- a/bootc/rhsm.sh
+++ b/bootc/rhsm.sh
@@ -5,9 +5,10 @@ set -eux
 # Edit RHSM_ values for the subscription configuration
 RHSM_USER=unset
 RHSM_PASSWORD=unset
-RHSM_REPOS="--enable=rhoso-18.0-for-rhel-9-x86_64-rpms \
-            --enable=rhceph-8-tools-for-rhel-9-x86_64-rpms \
-            --enable=fast-datapath-for-rhel-9-x86_64-rpms"
+RHEL_MAJOR=${RHEL_MAJOR:-9}
+RHSM_REPOS=${RHSM_REPOS:-"--enable=rhoso-18.0-for-rhel-${RHEL_MAJOR}-x86_64-rpms \
+            --enable=rhceph-8-tools-for-rhel-${RHEL_MAJOR}-x86_64-rpms \
+            --enable=fast-datapath-for-rhel-${RHEL_MAJOR}-x86_64-rpms"}
 # Only required when Simple Content Access (SCA) is disabled
 RHSM_POOL=""
 

--- a/dib/repo-setup/README.md
+++ b/dib/repo-setup/README.md
@@ -9,6 +9,9 @@ managed with the following environment variables (with these defaults):
 * DIB_REPO_SETUP_DISTRO_MIRROR=
 * DIB_REPO_SETUP_MIRROR=https://trunk.rdoproject.org
 
+**Note:** ``current-podified`` is not yet available for CentOS Stream 10. Use
+``DIB_REPO_SETUP=current`` until promotion to ``current-podified`` includes the required fixes.
+
 If DIB_YUM_REPO_CONF is defined, this element will take no action. This makes it
 possible to pass in repo files from the host.
 

--- a/dib/repo-setup/pre-install.d/00-03-repo-setup
+++ b/dib/repo-setup/pre-install.d/00-03-repo-setup
@@ -22,7 +22,6 @@ repo_setup="repo-setup --output-path repos --branch $DIB_REPO_SETUP_BRANCH --rdo
 if [ -n "$DIB_REPO_SETUP_DISTRO_MIRROR" ]; then
     repo_setup+=" --mirror $DIB_REPO_SETUP_DISTRO_MIRROR"
 fi
-repo_setup+=" $DIB_REPO_SETUP"
 
 mkdir repos
 eval $repo_setup

--- a/images/edpm-hardened-uefi-centos-10-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-10-stream.yaml
@@ -1,0 +1,37 @@
+- imagename: edpm-hardened-uefi
+  types: [qcow2]
+  elements:
+  # diskimage-builder elements
+  - centos
+  - selinux-permissive
+  - stable-interface-names
+  - bootloader
+  - element-manifest
+  - dynamic-login
+  - dracut-regenerate
+  - modprobe
+  - disable-nouveau
+  - reset-bls-entries
+  # edpm-image-builder elements
+  - edpm-base
+  - edpm-partition-uefi
+  - enable-packages-install
+  - interface-names
+  - openvswitch
+  - override-pip-and-virtualenv
+  - cloud-init-network-renderer
+  - remove-resolvconf
+  - repo-setup
+  min-tmpfs: 7
+  debug-trace: 1
+  checksum: true
+  environment:
+    DIB_RELEASE: '10-stream'
+    DIB_EPEL_DISABLED: '1'
+    DIB_PYTHON_VERSION: '3'
+    DIB_DHCP_TIMEOUT: '60'
+    DIB_IMAGE_SIZE: '5'
+    DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
+    DIB_BOOTLOADER_DEFAULT_CMDLINE: 'rd.multipath=default'
+    DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''
+    DIB_BOOTLOADER_USE_SERIAL_CONSOLE: 'False'

--- a/images/edpm-hardened-uefi-rhel-10.yaml
+++ b/images/edpm-hardened-uefi-rhel-10.yaml
@@ -1,0 +1,35 @@
+- imagename: edpm-hardened-uefi
+  types: [qcow2]
+  elements:
+  # diskimage-builder elements
+  - rhel
+  - stable-interface-names
+  - bootloader
+  - element-manifest
+  - dynamic-login
+  - dracut-regenerate
+  - modprobe
+  - disable-nouveau
+  - reset-bls-entries
+  # edpm-image-builder elements
+  - edpm-base
+  - edpm-partition-uefi
+  - enable-packages-install
+  - interface-names
+  - openvswitch
+  - override-pip-and-virtualenv
+  - cloud-init-network-renderer
+  - remove-resolvconf
+  - repo-setup
+  min-tmpfs: 7
+  debug-trace: 1
+  checksum: true
+  environment:
+    DIB_RELEASE: '10'
+    DIB_PYTHON_VERSION: '3'
+    DIB_DHCP_TIMEOUT: '60'
+    DIB_IMAGE_SIZE: '5'
+    DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
+    DIB_BOOTLOADER_DEFAULT_CMDLINE: 'rd.multipath=default'
+    DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''
+    DIB_BOOTLOADER_USE_SERIAL_CONSOLE: 'False'

--- a/images/ironic-python-agent-centos-10-stream.yaml
+++ b/images/ironic-python-agent-centos-10-stream.yaml
@@ -1,7 +1,7 @@
 - imagename: ironic-python-agent
   elements:
   # diskimage-builder elements
-  - rhel
+  - centos
   - dynamic-login
   - element-manifest
   - selinux-permissive
@@ -18,7 +18,6 @@
   debug-trace: 1
   checksum: true
   environment:
-    DIB_RELEASE: '9'
-    DIB_EPEL_DISABLED: '1'
+    DIB_RELEASE: '10-stream'
     DIB_PYTHON_VERSION: '3'
     DIB_DHCP_TIMEOUT: '60'

--- a/images/ironic-python-agent-rhel-10.yaml
+++ b/images/ironic-python-agent-rhel-10.yaml
@@ -18,7 +18,7 @@
   debug-trace: 1
   checksum: true
   environment:
-    DIB_RELEASE: '9'
+    DIB_RELEASE: '10'
     DIB_EPEL_DISABLED: '1'
     DIB_PYTHON_VERSION: '3'
     DIB_DHCP_TIMEOUT: '60'

--- a/playbooks/pre-deploy-cs10-bootstrap.yml
+++ b/playbooks/pre-deploy-cs10-bootstrap.yml
@@ -1,0 +1,27 @@
+---
+- name: Set up CS10 bootstrap kustomization
+  hosts: controller
+  gather_facts: false
+  vars:
+    _basedir: "{{ cifmw_basedir | default(ansible_user_dir ~ '/ci-framework-data') }}"
+    _manifests_dir: "{{ cifmw_manifests | default(_basedir ~ '/artifacts/manifests') }}"
+  tasks:
+    - name: Ensure kustomization directory exists
+      ansible.builtin.file:
+        path: "{{ _manifests_dir }}/kustomizations/dataplane"
+        state: directory
+        mode: "0755"
+
+    - name: Write CS10 bootstrap kustomization
+      ansible.builtin.copy:
+        dest: "{{ _manifests_dir }}/kustomizations/dataplane/cs10-bootstrap.yaml"
+        content: |
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          patches:
+            - target:
+                kind: OpenStackDataPlaneNodeSet
+              patch: |-
+                - op: add
+                  path: /spec/nodeTemplate/ansible/ansibleVars/edpm_bootstrap_command
+                  value: sudo dnf -y update --nobest

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,17 +1,41 @@
 ---
 - job:
-    name: eib-content-provider-build-images
+    name: eib-content-provider-build-images-cs9
     parent: content-provider-build-images-base
-    nodeset: centos-stream-9
+
+- job:
+    name: eib-content-provider-build-images-cs10
+    parent: content-provider-build-images-base
+    nodeset: centos-stream-10
+    vars:
+      cifmw_repo_setup_dist_major_version: 10
+      cifmw_repo_setup_branch: master
+      cifmw_repo_setup_promotion: current
+      cifmw_edpm_build_images_base_image: quay.io/centos/centos:stream10-minimal
 
 - job:
     name: eib-crc-podified-edpm-baremetal
     parent: cifmw-crc-podified-edpm-baremetal
-    dependencies: ["eib-content-provider-build-images"]
+    dependencies: ["eib-content-provider-build-images-cs9"]
+    vars:
+      cifmw_update_containers_openstack: true
+
+- job:
+    name: eib-crc-podified-edpm-baremetal-cs10
+    parent: cifmw-crc-podified-edpm-baremetal
+    dependencies: ["eib-content-provider-build-images-cs10"]
+    vars:
+      cifmw_update_containers_openstack: true
+      cifmw_install_yamls_vars_patch_cs10:
+        dataplane_repo_setup_repo: current
+        dataplane_repo_setup_branch: master
+      cifmw_edpm_deploy_baremetal_custom_bootstrap: true
+    pre-run:
+      - playbooks/pre-deploy-cs10-bootstrap.yml
 
 - job:
     name: eib-podified-multinode-ironic-deployment
     parent: podified-multinode-ironic-deployment
-    dependencies: ["eib-content-provider-build-images"]
+    dependencies: ["eib-content-provider-build-images-cs9"]
     vars:
       cifmw_update_containers_ipa_image_url: "{{ cifmw_build_images_output['images']['ironic-python-agent']['image'] }}"

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,6 +3,8 @@
     name: openstack-k8s-operators/edpm-image-builder
     github-check:
       jobs:
-        - eib-content-provider-build-images
-        - eib-podified-multinode-ironic-deployment
+        - eib-content-provider-build-images-cs9
+        - eib-content-provider-build-images-cs10
         - eib-crc-podified-edpm-baremetal
+        - eib-crc-podified-edpm-baremetal-cs10
+        - eib-podified-multinode-ironic-deployment


### PR DESCRIPTION
Add new DIB image entrypoints for CentOS Stream 10 and RHEL 10, make the existing RHEL 9 IPA release explicit, and update the local Zuul content-provider job to build on CentOS Stream 10.

Also add jobs to deployment with Centos stream 10 edpm image.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1146

jira: [OSPRH-29940](https://redhat.atlassian.net/browse/OSPRH-29940)