### PR TITLE
Add CentOS Stream 10 bootc image build and deploy job

### DIFF
--- a/bootc/README.rst
+++ b/bootc/README.rst
@@ -15,14 +15,15 @@ then run the following commands::
     export EDPM_BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream10
     export REPO_SETUP_DISTRO=centos10
     export REPO_SETUP_BRANCH=master
-    export REPO_SETUP=podified-ci-testing
+    export REPO_SETUP=current
     make build
     sudo podman push $EDPM_BOOTC_REPO:$EDPM_BOOTC_TAG
 
 .. note::
 
    ``current-podified`` is not yet available for CentOS Stream 10. The above
-   uses ``podified-ci-testing`` and ``master`` branch until it is.
+   uses ``current`` and ``master`` branch until promotion to
+   ``current-podified`` includes the required fixes.
 
 To continue using CentOS Stream 9, leave the defaults in place and run
 ``make build`` (the default tag is ``latest``).

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2,16 +2,22 @@
 - job:
     name: eib-content-provider-build-images-cs9
     parent: content-provider-build-images-base
+    timeout: 2700
+    vars:
+      cifmw_edpm_build_images_bootc: true
 
 - job:
     name: eib-content-provider-build-images-cs10
     parent: content-provider-build-images-base
     nodeset: centos-stream-10
+    timeout: 2700
     vars:
       cifmw_repo_setup_dist_major_version: 10
       cifmw_repo_setup_branch: master
       cifmw_repo_setup_promotion: current
       cifmw_edpm_build_images_base_image: quay.io/centos/centos:stream10-minimal
+      cifmw_edpm_build_images_bootc: true
+      cifmw_edpm_build_images_bootc_base_image: quay.io/centos-bootc/centos-bootc:stream10
 
 - job:
     name: eib-crc-podified-edpm-baremetal
@@ -32,6 +38,27 @@
       cifmw_edpm_deploy_baremetal_custom_bootstrap: true
     pre-run:
       - playbooks/pre-deploy-cs10-bootstrap.yml
+
+- job:
+    name: eib-crc-podified-edpm-baremetal-bootc
+    parent: cifmw-crc-podified-edpm-baremetal-bootc
+    dependencies: ["eib-content-provider-build-images-cs9"]
+    vars:
+      cifmw_update_containers_openstack: true
+      cifmw_install_yamls_vars:
+        BAREMETAL_OS_IMG: edpm-bootc.qcow2
+
+- job:
+    name: eib-crc-podified-edpm-baremetal-bootc-cs10
+    parent: cifmw-crc-podified-edpm-baremetal-bootc
+    dependencies: ["eib-content-provider-build-images-cs10"]
+    vars:
+      cifmw_update_containers_openstack: true
+      cifmw_install_yamls_vars:
+        BAREMETAL_OS_IMG: edpm-bootc.qcow2
+      cifmw_install_yamls_vars_patch_cs10:
+        dataplane_repo_setup_repo: current
+        dataplane_repo_setup_branch: master
 
 - job:
     name: eib-podified-multinode-ironic-deployment

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,4 +7,6 @@
         - eib-content-provider-build-images-cs10
         - eib-crc-podified-edpm-baremetal
         - eib-crc-podified-edpm-baremetal-cs10
+        - eib-crc-podified-edpm-baremetal-bootc
+        - eib-crc-podified-edpm-baremetal-bootc-cs10
         - eib-podified-multinode-ironic-deployment


### PR DESCRIPTION
CentOS Stream 9 and CentOS Stream 10 bootc jobs, with appropriate repo-setup parameters for each.

Will remove github actions in a separate PR.

jira: [OSPRH-29940](https://redhat.atlassian.net/browse/OSPRH-29940)