### PR TITLE
Build edpm-bootc image in OCI format

### DIFF
--- a/.github/workflows/edpm-bootc.yaml
+++ b/.github/workflows/edpm-bootc.yaml
@@ -65,6 +65,7 @@ jobs:
       with:
         image: edpm-bootc
         tags: ${{ env.latesttag }} ${{ github.sha }} ${{ env.podified }}
+        oci: true
         build-args:
           EDPM_BASE_IMAGE=${{ env.EDPM_BASE_IMAGE }}
         extra-args:


### PR DESCRIPTION
Ironic's OCI container registry client only requests application/vnd.oci.image.index.v1+json or
application/vnd.oci.image.manifest.v1+json manifests. Since buildah-build defaults to Docker v2 schema2 format, quay.io falls back to serving a legacy schema1 manifest for the tag, which Ironic cannot parse ("the artifact index of type unknown does not contain a list of manifests"). Set oci: true so the image is pushed with a proper OCI manifest that Ironic can consume when deploying via PassThrough mode.

Depends-on: https://github.com/openstack-k8s-operators/edpm-image-builder/pull/102