### PR TITLE
Generate per-image checksum files in copy_out.sh

### DIFF
--- a/copy_out.sh
+++ b/copy_out.sh
@@ -39,6 +39,7 @@ if [ ! -f $src_checksum ]; then
 fi
 
 dest_checksum=${DEST_DIR%%/}/${CHECKSUM_FILE}
+checksum_ext="${CHECKSUM_FILE##*.qcow2}"
 touch $dest_checksum
 while read -r checksum_entry; do
     file_name=$(echo "$checksum_entry" | cut -d " " -f 3)
@@ -56,6 +57,13 @@ while read -r checksum_entry; do
     fi
     if [[ $do_copy -eq 1 ]]; then
         cp -v $src_file_name $dest_file_name
+    fi
+    # Generate per-image checksum file so each image is individually
+    # addressable via <image-name>.sha256 by URL convention.
+    per_image_checksum="${DEST_DIR%%/}/${file_name}${checksum_ext}"
+    if [ ! -f "$per_image_checksum" ]; then
+        echo "$checksum_entry" > "$per_image_checksum"
+        echo "Generated per-image checksum: $per_image_checksum"
     fi
 done < $src_checksum
 cp -v $src_checksum $dest_checksum


### PR DESCRIPTION
## Problem

When the combined checksum file (`edpm-hardened-uefi.qcow2.sha256`)
contains entries for multiple images (e.g. both `edpm-hardened-uefi.qcow2`
and `edpm-hardened-uefi-9.6.qcow2`), only the combined file is available
on the ProvisionServer httpd. Individual per-image files like
`edpm-hardened-uefi-9.6.qcow2.sha256` do not exist.

Consumers creating BMH resources directly (outside of OSBMS, e.g. for
scale-out scenarios with mixed RHEL versions) naturally reference
`<image-name>.sha256` as the checksum URL in `spec.image.checksum`.
This results in a 404 from the httpd, causing Ironic provisioning to
fail.

## Solution

Extend the existing image-copy loop in `copy_out.sh` to also generate
a per-image checksum file for each entry that doesn't already have one.
No second loop is added -- the generation happens inline alongside the
existing copy logic.

Result on the httpd:
```
edpm-hardened-uefi.qcow2.sha256      (combined, unchanged)
edpm-hardened-uefi-9.6.qcow2.sha256  (per-image, new)
```

Both the combined file and the per-image files are available, so
either convention works. Existing single-image deployments are
unaffected.

## Testing

Tested locally with a combined checksum file containing two entries.
After running `copy_out.sh`, both per-image `.sha256` files are
generated in `$DEST_DIR`.