### PR TITLE
Harden build pipeline: pin build-time dependencies and secure credential handling

### DIFF
--- a/bootc/install-repo-setup.sh
+++ b/bootc/install-repo-setup.sh
@@ -2,9 +2,17 @@
 
 set -eux
 
+# Pin repo-setup to a specific commit on the stable branch
+# To update: change REPO_SETUP_COMMIT, download the new archive, and update REPO_SETUP_SHA256
+REPO_SETUP_COMMIT=85321f7e0af502d7f06f845886058daf09da34f6
+REPO_SETUP_SHA256=1050e4ed0472098165c4bde84a9991a6a13171426d16862f6651e28635d1727f
+
 pushd output
-curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar xvz
-pushd repo-setup-main
+curl -sL -o repo-setup.tar.gz \
+    "https://github.com/openstack-k8s-operators/repo-setup/archive/${REPO_SETUP_COMMIT}.tar.gz"
+echo "${REPO_SETUP_SHA256}  repo-setup.tar.gz" | sha256sum -c -
+tar xzf repo-setup.tar.gz
+pushd "repo-setup-${REPO_SETUP_COMMIT}"
 python3 -m venv ./venv
 source ./venv/bin/activate
 PBR_VERSION=0.0.0 python3 -m pip install ./

--- a/bootc/rhsm.sh
+++ b/bootc/rhsm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -eu
 
 # Edit RHSM_ values for the subscription configuration
 RHSM_USER=unset
@@ -13,8 +13,11 @@ RHSM_REPOS=${RHSM_REPOS:-"--enable=rhoso-18.0-for-rhel-${RHEL_MAJOR}-x86_64-rpms
 RHSM_POOL=""
 
 rm -f /etc/yum.repos.d/*.repo
-subscription-manager register --username=$RHSM_USER --password=$RHSM_PASSWORD
+# Suppress xtrace to avoid leaking credentials to the build log
+set +x
+subscription-manager register --username="$RHSM_USER" --password="$RHSM_PASSWORD"
+set -x
 if [ -n "${RHSM_POOL}" ]; then
-    subscription-manager attach --pool=$RHSM_POOL
+    subscription-manager attach --pool="$RHSM_POOL"
 fi
 subscription-manager repos $RHSM_REPOS

--- a/bootc/rhsm.sh
+++ b/bootc/rhsm.sh
@@ -13,6 +13,14 @@ RHSM_REPOS=${RHSM_REPOS:-"--enable=rhoso-18.0-for-rhel-${RHEL_MAJOR}-x86_64-rpms
 RHSM_POOL=""
 
 rm -f /etc/yum.repos.d/*.repo
+# Disable subscription-manager container detection so that registration
+# works during container builds. subscription-manager checks for
+# /etc/rhsm-host (a symlink to ../run/secrets/rhsm) to detect
+# container mode.
+if [ -L /etc/rhsm-host ]; then
+    rm -f /etc/rhsm-host
+fi
+
 # Suppress xtrace to avoid leaking credentials to the build log
 set +x
 subscription-manager register --username="$RHSM_USER" --password="$RHSM_PASSWORD"

--- a/dib/repo-setup/pre-install.d/00-03-repo-setup
+++ b/dib/repo-setup/pre-install.d/00-03-repo-setup
@@ -9,10 +9,16 @@ if [ -n "${DIB_YUM_REPO_CONF:-}" ] ; then
     exit 0
 fi
 
-# Install latest version of repo-setup without installing pip or git
+# Install repo-setup pinned to a specific commit on the stable branch
+# To update: change REPO_SETUP_COMMIT, download the new archive, and update REPO_SETUP_SHA256
+REPO_SETUP_COMMIT=85321f7e0af502d7f06f845886058daf09da34f6
+REPO_SETUP_SHA256=1050e4ed0472098165c4bde84a9991a6a13171426d16862f6651e28635d1727f
 cd /tmp
-curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar xvz
-cd repo-setup-main
+curl -sL -o repo-setup.tar.gz \
+    "https://github.com/openstack-k8s-operators/repo-setup/archive/${REPO_SETUP_COMMIT}.tar.gz"
+echo "${REPO_SETUP_SHA256}  repo-setup.tar.gz" | sha256sum -c -
+tar xzf repo-setup.tar.gz
+cd "repo-setup-${REPO_SETUP_COMMIT}"
 python3 -m venv ./venv
 source ./venv/bin/activate
 PBR_VERSION=0.0.0 python3 -m pip install ./


### PR DESCRIPTION
### Summary

Address build pipeline security findings identified by Project Glasswing ([HCMSEC-3528](https://redhat.atlassian.net/browse/HCMSEC-3528)). This PR pins the `repo-setup` build-time dependency to a verified commit and fixes RHSM credential leakage to build logs.

### Changes

**Pin repo-setup to commit SHA on stable with checksum verification**

The `repo-setup` tool was downloaded from the floating `main` branch via `curl | tar` with no integrity check and executed as root inside the image chroot. Both the diskimage-builder element (`dib/repo-setup/pre-install.d/00-03-repo-setup`) and the bootc path (`bootc/install-repo-setup.sh`) now pin to a specific commit on the `stable` branch and verify the SHA-256 checksum of the downloaded archive before extraction. The build will fail if the checksum does not match.

Jira: [OSPRH-32780](https://redhat.atlassian.net/browse/OSPRH-32780)

**Suppress RHSM credential exposure in build logs**

The RHSM registration template (`bootc/rhsm.sh`) used `set -eux`, causing `subscription-manager register --password=...` to be expanded to stderr and captured in build logs. The global `-x` flag has been removed and xtrace is explicitly suppressed around the credential-bearing command. Variable expansions are now properly quoted.

Jira: [OSPRH-32782](https://redhat.atlassian.net/browse/OSPRH-32782)

**Disable subscription-manager container mode detection during registration**

`subscription-manager` detects container mode via the `/etc/rhsm-host` symlink and exits with status 78, preventing registration during container builds. The symlink is now removed before registration to allow `subscription-manager register` to function during `buildah bud`.

### Testing

- CentOS Stream 9 bootc build (default path, no RHSM) continues to work unchanged
- RHEL bootc build with RHSM registration completes without exit status 78
- Build logs no longer contain plaintext RHSM credentials
- `repo-setup` fetch fails if the archive checksum does not match the pinned value