### PR TITLE
Use build secret instead of COPY for RHSM credential script

### DIFF
--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -114,9 +114,8 @@ ARG NVMEOF_PACKAGES="\
 
 ARG USER_PACKAGES=""
 
-ARG RHSM_SCRIPT=empty.sh
-COPY $RHSM_SCRIPT /var/tmp/rhsm-script.sh
-RUN /var/tmp/rhsm-script.sh && \
+RUN --mount=type=secret,id=rhsm,dst=/var/tmp/rhsm-script.sh \
+    if [ -f /var/tmp/rhsm-script.sh ]; then bash /var/tmp/rhsm-script.sh; fi && \
     dnf -y install \
         $BOOTSTRAP_PACKAGES \
         $CEPH_PACKAGES \

--- a/bootc/Makefile
+++ b/bootc/Makefile
@@ -8,8 +8,9 @@ EDPM_QCOW2_IMAGE ?= ${EDPM_BOOTC_REPO}:${EDPM_BOOTC_TAG}-qcow2
 BUILDER_IMAGE ?= quay.io/centos-bootc/bootc-image-builder:latest
 HOST_PACKAGES ?= podman osbuild-selinux https://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
 USER_PACKAGES ?=
-RHSM_SCRIPT ?= empty.sh
+RHSM_SCRIPT ?=
 FIPS ?= 1
+comma := ,
 
 .ONESHELL:
 
@@ -34,9 +35,9 @@ build: output/yum.repos.d
 	sudo buildah inspect ${EDPM_BOOTC_IMAGE} > /dev/null && exit 0 || true
 	sudo buildah bud \
 		--build-arg EDPM_BASE_IMAGE=${EDPM_BASE_IMAGE} \
-		--build-arg RHSM_SCRIPT=${RHSM_SCRIPT} \
 		--build-arg FIPS=${FIPS} \
 		--build-arg USER_PACKAGES=${USER_PACKAGES} \
+		$(if ${RHSM_SCRIPT},--secret id=rhsm$(comma)src=${RHSM_SCRIPT}) \
 		--volume /etc/pki/ca-trust:/etc/pki/ca-trust:ro,Z \
 		--volume $(shell pwd)/output/yum.repos.d:/etc/yum.repos.d:rw,Z \
 		-f ${EDPM_CONTAINERFILE} \

--- a/bootc/README.rst
+++ b/bootc/README.rst
@@ -82,8 +82,10 @@ packages, run the following commands::
     export RHEL_MAJOR=9
 
     # make a custom copy of the subscription-manager script and edit it for
-    # your registration details
+    # your registration details. The script is mounted as a build secret and
+    # will not be committed to any image layer.
     cp rhsm.sh rhsm-custom.sh
+    # edit RHSM_USER and RHSM_PASSWORD in rhsm-custom.sh
     export RHSM_SCRIPT=rhsm-custom.sh
 
     export EDPM_BOOTC_REPO=quay.io/<account>/edpm-bootc


### PR DESCRIPTION
Replace COPY of the RHSM credential script with
RUN --mount=type=secret so that credentials are never committed to an image layer. Previously, the documented RHEL build flow would embed plaintext RHSM_USER and RHSM_PASSWORD in the image layer history, recoverable by anyone with pull access to the registry.

The Containerfile now mounts the script as a build secret and guards execution with an existence check, so builds without RHSM (the default CentOS/CI path) continue to work unchanged. The Makefile conditionally passes --secret only when RHSM_SCRIPT is set.

Jira: [OSPRH-32781](https://redhat.atlassian.net/browse/OSPRH-32781)