### PR TITLE
Extend default /boot size for RHEL 9 edpm image definition <JIRA:OSPRH-32455>

### DIFF
--- a/dib/edpm-partition-uefi/block-device-default.yaml
+++ b/dib/edpm-partition-uefi/block-device-default.yaml
@@ -1,5 +1,5 @@
 # This file was generated with:
-# block-device-yaml --disk-size 5GiB --output dib/edpm-partition-uefi/block-device-default.yaml
+# block-device-yaml --disk-size 7GiB --boot-size 2048MiB --output dib/edpm-partition-uefi/block-device-default.yaml
 # See: https://github.com/openstack-k8s-operators/edpm-image-builder/
 - local_loop:
     name: image0
@@ -22,7 +22,7 @@
         size: 8MiB
       - name: boot
         type: 'BC13C2FF-59E6-4262-A352-B275FD6F7172'
-        size: 500MiB
+        size: 2048MiB
         mkfs:
           type: ext4
           mount:
@@ -32,9 +32,9 @@
               fsck-passno: 1
       - name: root
         flags: [ boot ]
-        # The passed-in DIB_IMAGE_SIZE is 5120MiB
+        # The passed-in DIB_IMAGE_SIZE is 7168MiB
         # Otherwise, there is a 2MiB overhead
-        size: 4410MiB
+        size: 4910MiB
 - lvm:
     name: lvm
     base: [ root ]
@@ -51,12 +51,12 @@
           type: thin-pool
           base: vg
           # 20MiB overhead from root partition size
-          size: 4390MiB
+          size: 4890MiB
         - name: lv_root
           type: thin
           thin-pool: lv_thinpool
           base: vg
-          size: 2236MiB
+          size: 2736MiB
         - name: lv_tmp
           type: thin
           thin-pool: lv_thinpool

--- a/images/edpm-hardened-uefi-centos-9-stream.yaml
+++ b/images/edpm-hardened-uefi-centos-9-stream.yaml
@@ -30,7 +30,7 @@
     DIB_EPEL_DISABLED: '1'
     DIB_PYTHON_VERSION: '3'
     DIB_DHCP_TIMEOUT: '60'
-    DIB_IMAGE_SIZE: '5'
+    DIB_IMAGE_SIZE: '7'
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
     DIB_BOOTLOADER_DEFAULT_CMDLINE: 'rd.multipath=default'
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''

--- a/images/edpm-hardened-uefi-rhel-9.yaml
+++ b/images/edpm-hardened-uefi-rhel-9.yaml
@@ -28,7 +28,7 @@
     DIB_RELEASE: '9'
     DIB_PYTHON_VERSION: '3'
     DIB_DHCP_TIMEOUT: '60'
-    DIB_IMAGE_SIZE: '5'
+    DIB_IMAGE_SIZE: '7'
     DIB_MODPROBE_BLACKLIST: 'usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf bluetooth'
     DIB_BOOTLOADER_DEFAULT_CMDLINE: 'rd.multipath=default'
     DIB_BOOTLOADER_VIRTUAL_TERMINAL: ''


### PR DESCRIPTION
**Description**:
The default 500MiB size of /boot causes [space constraints](https://redhat.atlassian.net/browse/OSPRH-31668) even when running with the default allowed 3 kernels, so it needs to be increased. Ran the command to increase /boot size to 2GiB and disk size to 7GiB and make the corresponding changes in rhel 9 and centos stream 9 configurations.

Jira: [OSPRH-32455](https://redhat.atlassian.net/browse/OSPRH-32455)