### PR TITLE
Change boot size default to 2048 <JIRA:OSPRH-32455>

### DIFF
--- a/block-device-yaml
+++ b/block-device-yaml
@@ -45,7 +45,7 @@ DEFAULT_MOUNT_OPTION = "rw,relatime"
 DEFAULT_PARTITION_SIZES = {
     "efi": 200,
     "bsp": 8,
-    "boot": 500,
+    "boot": 2048,
 }
 
 UNIT_BYTES = {"MiB": BYTES_MIB, "GiB": BYTES_GIB}
@@ -80,7 +80,7 @@ def get_args():
     )
     parser.add_argument(
         "--boot-size",
-        default="500MiB",
+        default="2048MiB",
         help="Size of the /boot partition, with a required unit MiB or GiB",
     )
     parser.add_argument(

--- a/dib/edpm-partition-uefi/block-device-default.yaml
+++ b/dib/edpm-partition-uefi/block-device-default.yaml
@@ -1,5 +1,5 @@
 # This file was generated with:
-# block-device-yaml --disk-size 7GiB --boot-size 2048MiB --output dib/edpm-partition-uefi/block-device-default.yaml
+# block-device-yaml --disk-size 7GiB --output dib/edpm-partition-uefi/block-device-default.yaml
 # See: https://github.com/openstack-k8s-operators/edpm-image-builder/
 - local_loop:
     name: image0


### PR DESCRIPTION
**Description:**
Following on from https://github.com/openstack-k8s-operators/edpm-image-builder/pull/106, the defaults in block-device-yaml should be what we prefer, so the boot size default has been changed to 2048 and `dib/edpm-partition-uefi/block-device-default.yaml` has been generated again. 

Jira: [OSPRH-32455](https://redhat.atlassian.net/browse/OSPRH-32455)